### PR TITLE
Search addresses integration tests

### DIFF
--- a/AddressesAPI.Tests/AddressesAPI.Tests.csproj
+++ b/AddressesAPI.Tests/AddressesAPI.Tests.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="DotNetEnv" Version="1.4.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="FluentValidation" Version="8.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.8" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.4" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />

--- a/AddressesAPI.Tests/IntegrationTests.cs
+++ b/AddressesAPI.Tests/IntegrationTests.cs
@@ -25,7 +25,6 @@ namespace AddressesAPI.Tests
         [OneTimeSetUp]
         public void OneTimeSetUp()
         {
-            Environment.SetEnvironmentVariable("ALLOWED_ADDRESSSTATUS_VALUES", "historical;alternative;approved preferred;provisional");
             // ConnectToPostgresDbUsingEf();
         }
 
@@ -33,6 +32,7 @@ namespace AddressesAPI.Tests
         public void BaseSetup()
         {
             ConnectToDbUsingSqlClient();
+            ClearDatabase();
             _factory = new MockWebApplicationFactory<TStartup>(_connection);
             Client = _factory.CreateClient();
             // StartTransactionWithEf();
@@ -80,6 +80,14 @@ namespace AddressesAPI.Tests
             _builder.UseNpgsql(_connection);
         }
 
+        private void ClearDatabase()
+        {
+            var commandText = "DELETE FROM [dbo].[hackney_address]; DELETE FROM [dbo].[national_address]; DELETE FROM [dbo].[hackney_xref];";
+
+            var command = new SqlCommand(commandText, Db);
+            command.ExecuteNonQuery();
+            command.Dispose();
+        }
 
         private void ConnectToDbUsingSqlClient()
         {

--- a/AddressesAPI.Tests/V1/Controllers/GetAddressCrossReferencesControllerTests.cs
+++ b/AddressesAPI.Tests/V1/Controllers/GetAddressCrossReferencesControllerTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using AddressesAPI.V1.Boundary.Requests;
 using AddressesAPI.V1.Boundary.Responses;
 using AddressesAPI.V1.Boundary.Responses.Data;
+using AddressesAPI.V1.Boundary.Responses.Metadata;
 using AddressesAPI.V1.Controllers;
 using AddressesAPI.V1.UseCase.Interfaces;
 using FluentAssertions;

--- a/AddressesAPI.Tests/V1/Controllers/SearchAddressControllerTests.cs
+++ b/AddressesAPI.Tests/V1/Controllers/SearchAddressControllerTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using AddressesAPI.V1;
 using AddressesAPI.V1.Boundary.Requests;
 using AddressesAPI.V1.Boundary.Responses;
+using AddressesAPI.V1.Boundary.Responses.Metadata;
 using AddressesAPI.V1.Controllers;
 using AddressesAPI.V1.UseCase;
 using AddressesAPI.V1.UseCase.Interfaces;

--- a/AddressesAPI.Tests/V1/E2ETests/SearchAddressIntegrationTests.cs
+++ b/AddressesAPI.Tests/V1/E2ETests/SearchAddressIntegrationTests.cs
@@ -1,9 +1,13 @@
 using System;
+using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using AddressesAPI.Tests.V1.Helper;
+using AddressesAPI.V1.Boundary.Requests;
 using AddressesAPI.V1.Boundary.Responses;
 using AddressesAPI.V1.Boundary.Responses.Metadata;
+using AutoFixture;
+using Bogus;
 using FluentAssertions;
 using Newtonsoft.Json;
 using NUnit.Framework;
@@ -12,6 +16,9 @@ namespace AddressesAPI.Tests.V1.E2ETests
 {
     public class SearchAddressIntegrationTests : IntegrationTests<Startup>
     {
+        private readonly Faker _faker = new Faker();
+        private readonly IFixture _fixture = new Fixture();
+
         [Test]
         public async Task SearchAddressReturns200()
         {
@@ -25,17 +32,181 @@ namespace AddressesAPI.Tests.V1.E2ETests
         }
 
         [Test]
-        public async Task SearchAddressReturnsAnAddress()
+        public async Task SearchAddressReturnsAnAddressWithMatchingPostcode()
         {
-            var addressKey = "eytshdnshsuahs";
+            var addressKey = _faker.Random.String2(14);
             TestDataHelper.InsertAddress(addressKey, Db);
+            AddSomeRandomAddressToTheDatabase();
 
-            var queryString = "PostCode=E82LX&AddressStatus=Historical";
+            var queryString = "PostCode=E82LX&AddressStatus=Historical&Format=Detailed";
 
             var response = await CallEndpointWithQueryParameters(queryString).ConfigureAwait(true);
             response.StatusCode.Should().Be(200);
             var returnedAddress = await ConvertToResponseObject(response).ConfigureAwait(true);
             returnedAddress.Data.Addresses.Count.Should().Be(1);
+            returnedAddress.Data.Addresses.First().AddressKey.Should().Be(addressKey);
+        }
+
+        [Test]
+        public async Task CanSearchAddressesByUprn()
+        {
+            var addressKey = _faker.Random.String2(14);
+            var queryParameters = new DatabaseAddressRecord
+            {
+                uprn = _faker.Random.Int(),
+            };
+            TestDataHelper.InsertAddress(addressKey, Db, queryParameters);
+            AddSomeRandomAddressToTheDatabase();
+
+            var queryString = $"UPRN={queryParameters.uprn}&AddressStatus=Historical&Format=Detailed";
+
+            var response = await CallEndpointWithQueryParameters(queryString).ConfigureAwait(true);
+            response.StatusCode.Should().Be(200);
+
+            var returnedAddress = await ConvertToResponseObject(response).ConfigureAwait(true);
+            returnedAddress.Data.Addresses.Count.Should().Be(1);
+            returnedAddress.Data.Addresses.First().AddressKey.Should().Be(addressKey);
+        }
+
+        [Test]
+        public async Task CanSearchAddressesByUsrn()
+        {
+            var addressKey = _faker.Random.String2(14);
+            var queryParameters = new DatabaseAddressRecord
+            {
+                usrn = _faker.Random.Int(),
+            };
+            TestDataHelper.InsertAddress(addressKey, Db, queryParameters);
+            AddSomeRandomAddressToTheDatabase();
+
+            var queryString = $"USRN={queryParameters.usrn}&AddressStatus=Historical&Format=Detailed";
+
+            var response = await CallEndpointWithQueryParameters(queryString).ConfigureAwait(true);
+            response.StatusCode.Should().Be(200);
+
+            var returnedAddress = await ConvertToResponseObject(response).ConfigureAwait(true);
+            returnedAddress.Data.Addresses.Count.Should().Be(1);
+            returnedAddress.Data.Addresses.First().AddressKey.Should().Be(addressKey);
+        }
+
+        [Test]
+        public async Task UsingTheSimpleFlagOnlyReturnsBasicAddressInformation()
+        {
+            var addressKey = _faker.Random.String2(14);
+            var addressDetails = new DatabaseAddressRecord
+            {
+                uprn = _faker.Random.Int(),
+                line1 = _faker.Address.StreetName(),
+                line2 = _faker.Address.StreetAddress(),
+                line3 = _faker.Address.County(),
+                line4 = _faker.Address.Country(),
+                town = _faker.Address.City(),
+                postcode = "E41JJ",
+            };
+            TestDataHelper.InsertAddress(addressKey, Db, addressDetails);
+            AddSomeRandomAddressToTheDatabase();
+            var queryString = $"UPRN={addressDetails.uprn}&AddressStatus=Historical&Format=Simple";
+
+            var response = await CallEndpointWithQueryParameters(queryString).ConfigureAwait(true);
+            response.StatusCode.Should().Be(200);
+
+            var returnedAddress = await ConvertToResponseObject(response).ConfigureAwait(true);
+            returnedAddress.Data.Addresses.Count.Should().Be(1);
+            var receivedAddress = returnedAddress.Data.Addresses.First();
+            receivedAddress.Should().BeEquivalentTo(new AddressResponse
+            {
+                Line1 = addressDetails.line1,
+                Line2 = addressDetails.line2,
+                Line3 = addressDetails.line3,
+                Line4 = addressDetails.line4,
+                Town = addressDetails.town,
+                Postcode = addressDetails.postcode,
+                UPRN = addressDetails.uprn
+            });
+        }
+
+        [Test]
+        public async Task SettingGazetteerToBothWillReturnNationalAddresses()
+        {
+            var addressKey = _faker.Random.String2(14);
+            var queryParameters = new DatabaseAddressRecord
+            {
+                uprn = _faker.Random.Int(),
+            };
+            TestDataHelper.InsertAddress(addressKey, Db, queryParameters, localOnly: false);
+
+            AddSomeRandomAddressToTheDatabase(count: 3);
+            AddSomeRandomAddressToTheDatabase(count: 3, gazetteer: "national");
+            var queryString = $"UPRN={queryParameters.uprn}&AddressStatus=Historical&Format=Detailed&Gazetteer=Both";
+
+            var response = await CallEndpointWithQueryParameters(queryString).ConfigureAwait(true);
+            response.StatusCode.Should().Be(200);
+
+            var returnedAddress = await ConvertToResponseObject(response).ConfigureAwait(true);
+            returnedAddress.Data.Addresses.Count.Should().Be(1);
+            returnedAddress.Data.Addresses.First().AddressKey.Should().Be(addressKey);
+        }
+
+        [Test]
+        public async Task MustQueryTheEndpointBySomethingWhenSearchingLocalAddresses()
+        {
+            var addressKey = "eytshdnshsuahs";
+            TestDataHelper.InsertAddress(addressKey, Db);
+
+            var queryString = "Gazetteer=Local";
+
+            var response = await CallEndpointWithQueryParameters(queryString).ConfigureAwait(true);
+            response.StatusCode.Should().Be(400);
+
+            var data = await ConvertToResponseObject(response).ConfigureAwait(true);
+            data.Error.IsValid.Should().BeFalse();
+            data.Error.ValidationErrors.Should()
+                .Contain(x => x.Message == "You must provide at least one of (uprn, usrn, postcode, street, usagePrimary, usageCode), when gazeteer is 'local'.");
+        }
+
+        [Test]
+        public async Task MustProvideAUprnUsrnOrPostcodeWhenSearchingNationalAddresses()
+        {
+            var addressKey = "eytshdnshsuahs";
+            TestDataHelper.InsertAddress(addressKey, Db);
+
+            var queryString = "Gazetteer=Both&street=hackneyroad";
+
+            var response = await CallEndpointWithQueryParameters(queryString).ConfigureAwait(true);
+            response.StatusCode.Should().Be(400);
+
+            var data = await ConvertToResponseObject(response).ConfigureAwait(true);
+            data.Error.IsValid.Should().BeFalse();
+            data.Error.ValidationErrors.Should()
+                .Contain(x => x.Message == "You must provide at least one of (uprn, usrn, postcode), when gazetteer is 'both'.");
+        }
+
+        [Test]
+        public async Task WillReturnABadRequestForAnInvalidPostcode()
+        {
+            var addressKey = "eytshdnshsuahs";
+            TestDataHelper.InsertAddress(addressKey, Db);
+
+            var queryString = "Gazetteer=Local&PostCode=12376";
+
+            var response = await CallEndpointWithQueryParameters(queryString).ConfigureAwait(true);
+            response.StatusCode.Should().Be(400);
+
+            var data = await ConvertToResponseObject(response).ConfigureAwait(true);
+            data.Error.IsValid.Should().BeFalse();
+            data.Error.ValidationErrors.Should()
+                .Contain(x => x.Message == "Must provide at least the first part of the postcode.");
+        }
+
+        private void AddSomeRandomAddressToTheDatabase(int? count = null, string gazetteer = "local")
+        {
+            var number = count ?? _faker.Random.Int(2, 7);
+            for (var i = 0; i < number; i++)
+            {
+                var addressKey = _faker.Random.String2(14);
+                var randomAddress = _fixture.Create<DatabaseAddressRecord>();
+                TestDataHelper.InsertAddress(addressKey, Db, randomAddress, gazetteer == "local");
+            }
         }
 
         private async Task<HttpResponseMessage> CallEndpointWithQueryParameters(string query)

--- a/AddressesAPI.Tests/V1/E2ETests/SearchAddressIntegrationTests.cs
+++ b/AddressesAPI.Tests/V1/E2ETests/SearchAddressIntegrationTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using AddressesAPI.Tests.V1.Helper;
 using AddressesAPI.V1.Boundary.Responses;
+using AddressesAPI.V1.Boundary.Responses.Metadata;
 using FluentAssertions;
 using Newtonsoft.Json;
 using NUnit.Framework;
@@ -11,24 +12,42 @@ namespace AddressesAPI.Tests.V1.E2ETests
 {
     public class SearchAddressIntegrationTests : IntegrationTests<Startup>
     {
-        [Ignore("In progress")]
         [Test]
         public async Task SearchAddressReturns200()
         {
-            var response = await CallEndpointWithQueryParameters().ConfigureAwait(true);
+            var addressKey = "eytshdnshsuahs";
+            TestDataHelper.InsertAddress(addressKey, Db);
+
+            var queryString = "PostCode=E8";
+
+            var response = await CallEndpointWithQueryParameters(queryString).ConfigureAwait(true);
             response.StatusCode.Should().Be(200);
         }
 
-        private async Task<HttpResponseMessage> CallEndpointWithQueryParameters()
+        [Test]
+        public async Task SearchAddressReturnsAnAddress()
         {
-            var url = new Uri("api/v1/addresses", UriKind.Relative);
+            var addressKey = "eytshdnshsuahs";
+            TestDataHelper.InsertAddress(addressKey, Db);
+
+            var queryString = "PostCode=E82LX&AddressStatus=Historical";
+
+            var response = await CallEndpointWithQueryParameters(queryString).ConfigureAwait(true);
+            response.StatusCode.Should().Be(200);
+            var returnedAddress = await ConvertToResponseObject(response).ConfigureAwait(true);
+            returnedAddress.Data.Addresses.Count.Should().Be(1);
+        }
+
+        private async Task<HttpResponseMessage> CallEndpointWithQueryParameters(string query)
+        {
+            var url = new Uri($"api/v1/addresses?{query}", UriKind.Relative);
             return await Client.GetAsync(url).ConfigureAwait(true);
         }
 
-        private static async Task<SearchAddressResponse> ConvertToResponseObject(HttpResponseMessage response)
+        private static async Task<APIResponse<SearchAddressResponse>> ConvertToResponseObject(HttpResponseMessage response)
         {
             var data = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
-            return JsonConvert.DeserializeObject<SearchAddressResponse>(data);
+            return JsonConvert.DeserializeObject<APIResponse<SearchAddressResponse>>(data);
         }
     }
 }

--- a/AddressesAPI.Tests/V1/Helper/AssertionHelpers.cs
+++ b/AddressesAPI.Tests/V1/Helper/AssertionHelpers.cs
@@ -1,6 +1,9 @@
+using System.Collections.Generic;
 using AddressesAPI.V1.Boundary.Responses;
 using AddressesAPI.V1.Domain;
 using FluentAssertions;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace AddressesAPI.Tests.V1.Helper
 {

--- a/AddressesAPI.Tests/V1/Helper/TestDatabaseHelper.cs
+++ b/AddressesAPI.Tests/V1/Helper/TestDatabaseHelper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel.DataAnnotations;
 using System.Data;
 using Microsoft.Data.SqlClient;
 
@@ -6,19 +7,40 @@ namespace AddressesAPI.Tests.V1.Helper
 {
     public static class TestDataHelper
     {
-        public static void InsertAddress(string key, SqlConnection db)
+        public static void InsertAddress(string key, SqlConnection db, DatabaseAddressRecord request = null, bool localOnly = true)
         {
-            var commandText = "INSERT [dbo].[hackney_address] ([lpi_key], [lpi_logical_status], [lpi_start_date], [lpi_end_date], [lpi_last_update_date], [usrn], [uprn], [parent_uprn], [blpu_start_date], [blpu_end_date], [blpu_state], [blpu_state_date], [blpu_class], [usage_description], [usage_primary], [property_shell], [easting], [northing], [organisation], [sao_text], [unit_number], [lpi_level], [pao_text], [building_number], [street_description], [locality], [ward], [town], [county], [postcode], [postcode_nospace], [planning_use_class], [neverexport], [longitude], [latitude], [gazetteer], [line1], [line2], [line3], [line4]) VALUES (@LPI_KEY, N'Historical', 20060214, 20060824, 20080623, 20900579, 10008227619, 100023650149, 20060214, 20090821, NULL, 0, N'RD', N'Residential, Dwellings', N'Residential', 0, CAST(533580.0000 AS Numeric(12, 4)), CAST(184945.0000 AS Numeric(12, 4)), NULL, NULL, N'37-38', NULL, N'DALSTON CROSS SHOPPING CENTRE', N'64', N'KINGSLAND HIGH STREET', N'HACKNEY', N'DALSTON WARD', N'LONDON', N'HACKNEY', N'E8 2LX', N'E82LX', NULL, 0, -0.074904309495184729, 51.54759585320371, N'LOCAL', N'37-38 DALSTON CROSS SHOPPING CENTRE', N'64 KINGSLAND HIGH STREET', N'LONDON', N'')";
+            var database = localOnly ? "hackney_address" : "national_address";
+            var commandText = $"INSERT [dbo].[{database}] ([lpi_key], [lpi_logical_status], [lpi_start_date], " +
+                                       "[lpi_end_date], [lpi_last_update_date], [blpu_last_update_date], [usrn], [uprn], [parent_uprn], [blpu_start_date], " +
+                                       "[blpu_end_date], [blpu_state], [blpu_state_date], [blpu_class], [usage_description], " +
+                                       "[usage_primary], [property_shell], [easting], [northing], [organisation], [sao_text], " +
+                                       "[unit_number], [lpi_level], [pao_text], [building_number], [street_description], [locality], " +
+                                       "[ward], [town], [county], [postcode], [postcode_nospace], [planning_use_class], [neverexport], " +
+                                       "[longitude], [latitude], [gazetteer], [line1], [line2], [line3], [line4]) " +
+                                       "VALUES (@LPI_KEY, N'Historical', 20060214, 20060824, 20080623, 20080623, @USRN, @UPRN, 100023650149, " +
+                                       "20060214, 20090821, NULL, 0, N'RD', N'Residential, Dwellings', N'Residential', 0, " +
+                                       "CAST(533580.0000 AS Numeric(12, 4)), CAST(184945.0000 AS Numeric(12, 4)), NULL, NULL, N'37-38', " +
+                                       "NULL, N'DALSTON CROSS SHOPPING CENTRE', N'64', N'KINGSLAND HIGH STREET', N'HACKNEY', " +
+                                       "N'DALSTON WARD', @TOWN, N'HACKNEY', @POSTCODE, @POSTCODE_NO_SPACE, NULL, 0, " +
+                                       "-0.074904309495184729, 51.54759585320371, N'LOCAL', @LINE_1, " +
+                                       "@LINE_2, @LINE_3, @LINE_4)";
 
             var command = new SqlCommand(commandText, db);
 
-            command.Parameters.Add("@LPI_KEY", SqlDbType.VarChar);
-            command.Parameters["@LPI_KEY"].Value = key;
+            command.Parameters.AddWithValue("@LPI_KEY", key);
+            command.Parameters.AddWithValue("@UPRN", request?.uprn ?? 10008227619);
+            command.Parameters.AddWithValue("@USRN", request?.usrn ?? 20900579);
+            command.Parameters.AddWithValue("@LINE_1", request?.line1 ?? "37-38 DALSTON CROSS SHOPPING CENTRE");
+            command.Parameters.AddWithValue("@LINE_2", request?.line2 ?? "64 KINGSLAND HIGH STREET");
+            command.Parameters.AddWithValue("@LINE_3", request?.line3 ?? "LONDON");
+            command.Parameters.AddWithValue("@LINE_4", request?.line4 ?? "");
+            command.Parameters.AddWithValue("@TOWN", request?.town ?? "LONDON");
+            command.Parameters.AddWithValue("@POSTCODE", request?.postcode ?? "E8 2LX");
+            command.Parameters.AddWithValue("@POSTCODE_NO_SPACE", request?.postcode?.Replace(" ", "") ?? "E82LX");
 
             command.ExecuteNonQuery();
             command.Dispose();
         }
-
         internal static void DeleteCrossRef(int uprn, SqlConnection db)
         {
             var commandText = "delete from [dbo].[hackney_xref] WHERE uprn = @uprn ";
@@ -61,6 +83,73 @@ namespace AddressesAPI.Tests.V1.Helper
             command.ExecuteNonQuery();
             command.Dispose();
         }
-
+    }
+    public class DatabaseAddressRecord
+    {
+        [MaxLength(14)]
+        public string lpi_key { get; set; }
+        [MaxLength(14)]
+        public string lpi_logical_status { get; set; }
+        public int lpi_start_date { get; set; }
+        public int? lpi_end_date { get; set; }
+        public int lpi_last_update_date { get; set; }
+        public int usrn { get; set; }
+        public long uprn { get; set; }
+        public float? parent_uprn { get; set; }
+        public int? blpu_start_date { get; set; }
+        public int? blpu_end_date { get; set; }
+        public short? blpu_state { get; set; }
+        public int? blpu_state_date { get; set; }
+        [MaxLength(4)]
+        public string blpu_class { get; set; }
+        [MaxLength(160)]
+        public string usage_description { get; set; }
+        [MaxLength(250)]
+        public string usage_primary { get; set; }
+        public bool property_shell { get; set; }
+        public decimal easting { get; set; }
+        public decimal northing { get; set; }
+        [MaxLength(100)]
+        public string organisation { get; set; }
+        [MaxLength(90)]
+        public string sao_text { get; set; }
+        [MaxLength(17)]
+        public string unit_number { get; set; }
+        [MaxLength(30)]
+        public string lpi_level { get; set; }
+        [MaxLength(90)]
+        public string pao_text { get; set; }
+        [MaxLength(17)]
+        public string building_number { get; set; }
+        [MaxLength(100)]
+        public string street_description { get; set; }
+        [MaxLength(35)]
+        public string locality { get; set; }
+        [MaxLength(100)]
+        public string ward { get; set; }
+        [MaxLength(30)]
+        public string town { get; set; }
+        [MaxLength(30)]
+        public string county { get; set; }
+        [MaxLength(8)]
+        public string postcode { get; set; }
+        [MaxLength(8)]
+        public string postcode_nospace { get; set; }
+        [MaxLength(50)]
+        public string planning_use_class { get; set; }
+        public bool neverexport { get; set; }
+        public float longitude { get; set; }
+        public float latitude { get; set; }
+        [MaxLength(5)]
+        public string gazetteer { get; set; }
+        [MaxLength(90)]
+        public string line1 { get; set; }
+        [MaxLength(120)]
+        public string line2 { get; set; }
+        [MaxLength(120)]
+        public string line3 { get; set; }
+        [MaxLength(30)]
+        public string line4 { get; set; }
+        public short? paon_start_num { get; set; }
     }
 }

--- a/AddressesAPI.Tests/V1/UseCase/SearchAddressValidatorTests.cs
+++ b/AddressesAPI.Tests/V1/UseCase/SearchAddressValidatorTests.cs
@@ -350,19 +350,5 @@ namespace AddressesAPI.Tests.V1.UseCase
         }
 
         #endregion
-
-        //Keep this at the end....
-        [Test]
-        public void GivenThereIsNoEnvironmentVariableForAddressStatus_WhenValidationIsInvoked_TheErrorIsReturned()
-        {
-            Environment.SetEnvironmentVariable("ALLOWED_ADDRESSSTATUS_VALUES", null);
-
-            Action createValidator = () =>
-            {
-                var dummy = new SearchAddressValidator();
-            };
-
-            createValidator.Should().Throw<MissingEnvironmentVariableException>();
-        }
     }
 }

--- a/AddressesAPI/AddressesAPI.csproj
+++ b/AddressesAPI/AddressesAPI.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="DotNetEnv" Version="1.4.0" />
     <PackageReference Include="FluentValidation" Version="8.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.8" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="4.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.1.3" />

--- a/AddressesAPI/Startup.cs
+++ b/AddressesAPI/Startup.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using AddressesAPI.V1.Boundary.Requests.RequestValidators;
 using AddressesAPI.V1.Gateways;
 using AddressesAPI.V1.Infrastructure;
 using AddressesAPI.V1.UseCase;
@@ -19,6 +18,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
+using Newtonsoft.Json.Converters;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace AddressesAPI
@@ -39,7 +39,10 @@ namespace AddressesAPI
         {
             services
                 .AddMvc()
-                .SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
+                .SetCompatibilityVersion(CompatibilityVersion.Version_3_0)
+                .AddNewtonsoftJson(options =>
+                    options.SerializerSettings.Converters.Add(new StringEnumConverter()))
+                .SetCompatibilityVersion(CompatibilityVersion.Version_3_0);;
             services.AddApiVersioning(o =>
             {
                 o.DefaultApiVersion = new ApiVersion(1, 0);

--- a/AddressesAPI/Startup.cs
+++ b/AddressesAPI/Startup.cs
@@ -42,7 +42,7 @@ namespace AddressesAPI
                 .SetCompatibilityVersion(CompatibilityVersion.Version_3_0)
                 .AddNewtonsoftJson(options =>
                     options.SerializerSettings.Converters.Add(new StringEnumConverter()))
-                .SetCompatibilityVersion(CompatibilityVersion.Version_3_0);;
+                .SetCompatibilityVersion(CompatibilityVersion.Version_3_0); ;
             services.AddApiVersioning(o =>
             {
                 o.DefaultApiVersion = new ApiVersion(1, 0);

--- a/AddressesAPI/V1/Boundary/Requests/SearchAddressRequest.cs
+++ b/AddressesAPI/V1/Boundary/Requests/SearchAddressRequest.cs
@@ -18,13 +18,9 @@ namespace AddressesAPI.V1.Boundary.Requests
 
         public SearchAddressRequest()
         {
-            this.AddressStatus = "approved preferred";
-            this.Gazetteer = GlobalConstants.Gazetteer.Both;
+            AddressStatus = "approved preferred";
+            Gazetteer = GlobalConstants.Gazetteer.Both;
         }
-
-        //    [FromQuery]string PropertyClassCode = null/*,
-        // Parent shells??
-
 
         /// <summary>
         /// Postcode partial match i.e. "E8 4" will return addresses that have a postcode starting with E84**
@@ -104,7 +100,6 @@ namespace AddressesAPI.V1.Boundary.Requests
         /// Approved Preferred (Default)
         /// Historical
         /// Provisional
-        /// Rejected Internal
         /// </summary>
         public string AddressStatus { get; set; }
 

--- a/AddressesAPI/V1/Boundary/Responses/Metadata/APIError.cs
+++ b/AddressesAPI/V1/Boundary/Responses/Metadata/APIError.cs
@@ -1,9 +1,8 @@
 using System;
 using System.Collections.Generic;
-using AddressesAPI.V1.Boundary.Responses;
 using LBHAddressesAPI.Infrastructure.V1.Validation;
 
-namespace LBHAddressesAPI.Infrastructure.V1.API
+namespace AddressesAPI.V1.Boundary.Responses.Metadata
 {
     public class APIError
     {
@@ -11,6 +10,7 @@ namespace LBHAddressesAPI.Infrastructure.V1.API
         public IList<ExecutionError> Errors { get; set; }
         public IList<ValidationError> ValidationErrors { get; set; }
 
+        public APIError() { }
         public APIError(RequestValidationResponse validationResponse)
         {
             if (validationResponse == null)

--- a/AddressesAPI/V1/Boundary/Responses/Metadata/APIResponse.cs
+++ b/AddressesAPI/V1/Boundary/Responses/Metadata/APIResponse.cs
@@ -3,7 +3,7 @@ using System.Net;
 using LBHAddressesAPI.Infrastructure.V1.API;
 using Newtonsoft.Json;
 
-namespace AddressesAPI.V1.Boundary.Responses
+namespace AddressesAPI.V1.Boundary.Responses.Metadata
 {
     /// <summary>
     /// API Response wrapper for all API responses
@@ -23,6 +23,11 @@ namespace AddressesAPI.V1.Boundary.Responses
 
         [JsonProperty("error")]
         public APIError Error { get; set; }
+
+        public APIResponse()
+        {
+
+        }
 
         public APIResponse(BadRequestException ex)
         {

--- a/AddressesAPI/V1/Boundary/Responses/Metadata/APIResponse.cs
+++ b/AddressesAPI/V1/Boundary/Responses/Metadata/APIResponse.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Net;
-using LBHAddressesAPI.Infrastructure.V1.API;
 using Newtonsoft.Json;
 
 namespace AddressesAPI.V1.Boundary.Responses.Metadata
@@ -24,10 +23,7 @@ namespace AddressesAPI.V1.Boundary.Responses.Metadata
         [JsonProperty("error")]
         public APIError Error { get; set; }
 
-        public APIResponse()
-        {
-
-        }
+        public APIResponse() { }
 
         public APIResponse(BadRequestException ex)
         {

--- a/AddressesAPI/V1/Controllers/BaseController.cs
+++ b/AddressesAPI/V1/Controllers/BaseController.cs
@@ -1,4 +1,5 @@
 using AddressesAPI.V1.Boundary.Responses;
+using AddressesAPI.V1.Boundary.Responses.Metadata;
 using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;

--- a/AddressesAPI/V1/Controllers/GetAddressController.cs
+++ b/AddressesAPI/V1/Controllers/GetAddressController.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using AddressesAPI.V1.Boundary.Requests;
 using AddressesAPI.V1.Boundary.Responses;
+using AddressesAPI.V1.Boundary.Responses.Metadata;
 using AddressesAPI.V1.UseCase.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 

--- a/AddressesAPI/V1/Controllers/GetAddressCrossReferenceController.cs
+++ b/AddressesAPI/V1/Controllers/GetAddressCrossReferenceController.cs
@@ -1,6 +1,7 @@
 using System.Threading.Tasks;
 using AddressesAPI.V1.Boundary.Requests;
 using AddressesAPI.V1.Boundary.Responses;
+using AddressesAPI.V1.Boundary.Responses.Metadata;
 using AddressesAPI.V1.UseCase.Interfaces;
 using Microsoft.AspNetCore.Mvc;
 

--- a/AddressesAPI/V1/Controllers/SearchAddressController.cs
+++ b/AddressesAPI/V1/Controllers/SearchAddressController.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using AddressesAPI.V1.Boundary.Requests;
 using AddressesAPI.V1.Boundary.Responses;
+using AddressesAPI.V1.Boundary.Responses.Metadata;
 using AddressesAPI.V1.UseCase.Interfaces;
 using LBHAddressesAPI.Infrastructure.V1.Validation;
 using Microsoft.AspNetCore.Mvc;

--- a/AddressesAPI/V1/Gateways/AddressesGatewayTSQL.cs
+++ b/AddressesAPI/V1/Gateways/AddressesGatewayTSQL.cs
@@ -71,7 +71,16 @@ namespace AddressesAPI.V1.Gateways
                     }
                     else
                     {
-                        var all = multi.Read<SimpleAddress>()?.Select(x => (Address) x).ToList();
+                        var all = multi.Read<SimpleAddress>()?.Select(x => new Address
+                        {
+                            Line1 = x.Line1,
+                            Line2 = x.Line2,
+                            Line3 = x.Line3,
+                            Line4 = x.Line4,
+                            Town = x.Town,
+                            Postcode = x.Postcode,
+                            UPRN = x.UPRN
+                        }).ToList();
                         totalCount = multi.Read<int>().Single();
                         result = all?.ToList();
                     }

--- a/AddressesAPI/V1/UseCase/SearchAddressValidator.cs
+++ b/AddressesAPI/V1/UseCase/SearchAddressValidator.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using AddressesAPI.V1.Boundary.Requests;
-using AddressesAPI.V1.Domain;
 using AddressesAPI.V1.UseCase.Interfaces;
 using FluentValidation;
 
@@ -59,7 +58,7 @@ namespace AddressesAPI.V1.UseCase
 
         private static bool CanBeAnyCombinationOfAllowedValues(string addressStatus)
         {
-            var allowedValues = new List<string>{ "historical", "alternative", "approved preferred", "provisional"};
+            var allowedValues = new List<string> { "historical", "alternative", "approved preferred", "provisional" };
             if (string.IsNullOrEmpty(addressStatus))
             {
                 return false;

--- a/AddressesAPI/V1/UseCase/SearchAddressValidator.cs
+++ b/AddressesAPI/V1/UseCase/SearchAddressValidator.cs
@@ -11,13 +11,8 @@ namespace AddressesAPI.V1.UseCase
 {
     public class SearchAddressValidator : AbstractValidator<SearchAddressRequest>, ISearchAddressValidator
     {
-        private readonly string[] _allowedAddressStatusValues;
-
         public SearchAddressValidator()
         {
-            try { _allowedAddressStatusValues = Environment.GetEnvironmentVariable("ALLOWED_ADDRESSSTATUS_VALUES").Split(";"); }
-            catch (Exception) { throw new MissingEnvironmentVariableException("ALLOWED_ADDRESSSTATUS_VALUES"); }
-
             RuleFor(r => r.AddressStatus).NotNull().NotEmpty();
             RuleFor(r => r.AddressStatus).Must(CanBeAnyCombinationOfAllowedValues).WithMessage("Value for the parameter is not valid.");
 
@@ -62,15 +57,16 @@ namespace AddressesAPI.V1.UseCase
                    || request.PostCode != null;
         }
 
-        private bool CanBeAnyCombinationOfAllowedValues(string addressStatus)
+        private static bool CanBeAnyCombinationOfAllowedValues(string addressStatus)
         {
+            var allowedValues = new List<string>{ "historical", "alternative", "approved preferred", "provisional"};
             if (string.IsNullOrEmpty(addressStatus))
             {
                 return false;
             }
             var separateValuesArray = addressStatus.Split(",");
 
-            return separateValuesArray.All(value => _allowedAddressStatusValues.Contains(value));
+            return separateValuesArray.All(value => allowedValues.Contains(value.ToLower()));
         }
     }
 }

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -36,6 +36,8 @@ CREATE TABLE dbo.hackney_address(
 	planning_use_class varchar(50) NULL,
 	neverexport bit NOT NULL,
 	longitude float NULL,
+	blpu_last_update_date int NULL,
+	paon_start_num smallint NULL,
 	latitude float NULL,
 	gazetteer varchar(5) NOT NULL,
 	line1 nvarchar(90) NULL,
@@ -50,6 +52,7 @@ CREATE TABLE dbo.national_address(
 	lpi_logical_status varchar(18) NULL,
 	lpi_start_date int NOT NULL,
 	lpi_end_date int NULL,
+    blpu_last_update_date int NULL,
 	lpi_last_update_date int NOT NULL,
 	usrn int NOT NULL,
 	uprn float NOT NULL,
@@ -57,7 +60,8 @@ CREATE TABLE dbo.national_address(
 	blpu_start_date int NOT NULL,
 	blpu_end_date int NULL,
 	blpu_state smallint NULL,
-	blpu_state_date int NOT NULL,
+	paon_start_num smallint NULL,
+	blpu_state_date int NULL,
 	blpu_class varchar(6) NOT NULL,
 	usage_description varchar(1006) NOT NULL,
 	usage_primary varchar(250) NOT NULL,
@@ -82,10 +86,10 @@ CREATE TABLE dbo.national_address(
 	longitude numeric(12, 9) NULL,
 	latitude numeric(12, 9) NULL,
 	gazetteer varchar(8) NOT NULL,
-	line1 varchar(max) NULL,
-	line2 varchar(max) NULL,
-	line3 varchar(max) NULL,
-	line4 varchar(max) NULL
+	line1 varchar(200) NULL,
+	line2 varchar(200) NULL,
+	line3 varchar(200) NULL,
+	line4 varchar(100) NULL
 )
 
 /****** Object:  Table [dbo].[hackney_xref]    Script Date: 04/04/2019 12:32:33 ******/

--- a/databaseTSQL/setup.sql
+++ b/databaseTSQL/setup.sql
@@ -4,7 +4,7 @@ GO
 USE StubAdd;
 GO
 
-/****** Object:  Table [dbo].[hackney_address]    Script Date: 04/04/2019 12:32:33 ******/
+/****** Object:  Table [dbo].[hackney_address]    Script Date: 01/10/2020 16:32:33 ******/
 SET ANSI_NULLS ON
 GO
 SET QUOTED_IDENTIFIER ON
@@ -20,6 +20,7 @@ CREATE TABLE [dbo].[hackney_address](
 	[parent_uprn] [float] NULL,
 	[blpu_start_date] [int] NULL,
 	[blpu_end_date] [int] NULL,
+	[blpu_last_update_date] [int] NULL,
 	[blpu_state] [smallint] NULL,
 	[blpu_state_date] [int] NULL,
 	[blpu_class] [varchar](4) NULL,
@@ -33,6 +34,7 @@ CREATE TABLE [dbo].[hackney_address](
 	[unit_number] [nvarchar](17) NULL,
 	[lpi_level] [nvarchar](30) NULL,
 	[pao_text] [nvarchar](90) NULL,
+	[paon_start_num] [smallint] NULL,
 	[building_number] [nvarchar](17) NULL,
 	[street_description] [nvarchar](100) NOT NULL,
 	[locality] [nvarchar](35) NULL,
@@ -52,7 +54,7 @@ CREATE TABLE [dbo].[hackney_address](
 	[line4] [nvarchar](30) NULL
 ) ON [PRIMARY]
 GO
-/****** Object:  Table [dbo].[national_address]    Script Date: 04/04/2019 12:32:33 ******/
+/****** Object:  Table [dbo].[national_address]    Script Date: 01/10/2020 16:32:33 ******/
 SET ANSI_NULLS ON
 GO
 SET QUOTED_IDENTIFIER ON
@@ -68,8 +70,9 @@ CREATE TABLE [dbo].[national_address](
 	[parent_uprn] [float] NULL,
 	[blpu_start_date] [int] NOT NULL,
 	[blpu_end_date] [int] NULL,
+	[blpu_last_update_date] [int] NOT NULL,
 	[blpu_state] [smallint] NULL,
-	[blpu_state_date] [int] NOT NULL,
+	[blpu_state_date] [int] NULL,
 	[blpu_class] [varchar](6) NOT NULL,
 	[usage_description] [varchar](1006) NOT NULL,
 	[usage_primary] [varchar](250) NOT NULL,
@@ -81,6 +84,7 @@ CREATE TABLE [dbo].[national_address](
 	[unit_number] [nvarchar](17) NULL,
 	[lpi_level] [nvarchar](30) NULL,
 	[pao_text] [nvarchar](90) NULL,
+	[paon_start_num] [smallint] NULL,
 	[building_number] [nvarchar](17) NULL,
 	[street_description] [nvarchar](100) NOT NULL,
 	[locality] [varchar](100) NULL,
@@ -94,13 +98,13 @@ CREATE TABLE [dbo].[national_address](
 	[longitude] [numeric](12, 9) NULL,
 	[latitude] [numeric](12, 9) NULL,
 	[gazetteer] [varchar](8) NOT NULL,
-	[line1] [varchar](max) NULL,
-	[line2] [varchar](max) NULL,
-	[line3] [varchar](max) NULL,
-	[line4] [varchar](max) NULL
-) ON [PRIMARY] TEXTIMAGE_ON [PRIMARY]
+	[line1] [nvarchar](200) NULL,
+	[line2] [nvarchar](200) NULL,
+	[line3] [nvarchar](200) NULL,
+	[line4] [nvarchar](100) NULL
+	) ON [PRIMARY]
 GO
-/****** Object:  Table [dbo].[hackney_xref]    Script Date: 04/04/2019 12:32:33 ******/
+/****** Object:  Table [dbo].[hackney_xref]    Script Date: 01/10/2020 16:32:33 ******/
 SET ANSI_NULLS ON
 GO
 SET QUOTED_IDENTIFIER ON
@@ -114,5 +118,5 @@ CREATE TABLE [dbo].[hackney_xref](
 	[xref_end_date] [date] NULL
 ) ON [PRIMARY]
 GO
-create view [dbo].[combined_address] as  SELECT * FROM dbo.hackney_address   UNION ALL  SELECT * FROM dbo.national_address   ; 
+create view [dbo].[combined_address] as  SELECT * FROM dbo.hackney_address   UNION ALL  SELECT * FROM dbo.national_address;
 GO


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/PA-383
## Describe this PR

### *What is the problem we're trying to solve*

Before making changes to the code base we want to ensure that current functionality is covered by E2E tests so that we don't break anything.
### *What changes have we introduced*

This PR adds E2E tests around the search address endpoint testing the key query parameters and some validation error as well. 
In addition to this it:
 - Changes the E2E test setup to empty the test database after each test.
- Changes the API's JSON serializer to use Newtonsoft (the default serializer for asp net core 3.0 changed to System.text.Json but this API was previously using newtonsoft)
- Removes the  `ALLOWED_ADDRESSSTATUS_VALUES` environment variable as this doesn't change between environments.
- Add some missing/ changed fields to the test database initialization script, setup.sql.

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

