### PR TITLE
Add get single address functionality into new gateway using EF

### DIFF
--- a/AddressesAPI.Tests/V1/Gateways/AddressGatewayTest.cs
+++ b/AddressesAPI.Tests/V1/Gateways/AddressGatewayTest.cs
@@ -736,5 +736,21 @@ namespace AddressesAPI.Tests.V1.Gateways
         //TODO
         #endregion
         #endregion
+
+        #region GetSingleAddress
+
+        [Test]
+        public void ItWillReturnADetailedRecordForASingleAddressRetrievedUsingTheAddressKey()
+        {
+            var addressKey = _faker.Random.String2(14);
+            var savedAddress = TestEfDataHelper.InsertAddress(DatabaseContext, addressKey);
+
+            var retrievedRecord = _classUnderTest.GetSingleAddress(addressKey);
+
+            retrievedRecord.Should().NotBeNull();
+            retrievedRecord.Should().BeEquivalentTo(savedAddress.ToDomain());
+        }
+
+        #endregion
     }
 }

--- a/AddressesAPI.Tests/V1/Gateways/AddressGatewayTest.cs
+++ b/AddressesAPI.Tests/V1/Gateways/AddressGatewayTest.cs
@@ -751,6 +751,14 @@ namespace AddressesAPI.Tests.V1.Gateways
             retrievedRecord.Should().BeEquivalentTo(savedAddress.ToDomain());
         }
 
+        [Test]
+        public void ItWillReturnNullIfAddressWithAMatchingKeyDoesNotExistInTheDatabase()
+        {
+            var addressKey = _faker.Random.String2(14);
+
+            _classUnderTest.GetSingleAddress(addressKey).Should().BeNull();
+        }
+
         #endregion
     }
 }

--- a/AddressesAPI/V1/Gateways/AddressesGateway.cs
+++ b/AddressesAPI/V1/Gateways/AddressesGateway.cs
@@ -75,7 +75,8 @@ namespace AddressesAPI.V1.Gateways
 
         public Address GetSingleAddress(string addressKey)
         {
-            return _addressesContext.Addresses.FirstOrDefault(add => add.AddressKey.Equals(addressKey)).ToDomain();
+            var addressRecord = _addressesContext.Addresses.FirstOrDefault(add => add.AddressKey.Equals(addressKey));
+            return addressRecord?.ToDomain();
         }
 
         public async Task<(List<SimpleAddress>, int)> SearchSimpleAddressesAsync(SearchParameters request)

--- a/AddressesAPI/V1/Gateways/AddressesGateway.cs
+++ b/AddressesAPI/V1/Gateways/AddressesGateway.cs
@@ -73,6 +73,11 @@ namespace AddressesAPI.V1.Gateways
             return (addresses, 0);
         }
 
+        public Address GetSingleAddress(string addressKey)
+        {
+            return _addressesContext.Addresses.FirstOrDefault(add => add.AddressKey.Equals(addressKey)).ToDomain();
+        }
+
         public async Task<(List<SimpleAddress>, int)> SearchSimpleAddressesAsync(SearchParameters request)
         {
             return (new List<SimpleAddress>(), 0);


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/PA-388

## Describe this PR

### *What is the problem we're trying to solve*

As part of the plan to migrate the address data from SQL DB to a Postgres DB, we want to set up the gateway methods to retain the same functionality but using EF and Postgres.

### *What changes have we introduced*

The get a single address gateway functionality has been replicated using EF and Postgres

#### _Checklist_

- [X] Added tests to cover all new production code
- [X] Checked all code for possible refactoring
- [X] Code pipeline builds correctly