### PR TITLE
Replicate get address cross references functionality to use EF core

### DIFF
--- a/AddressesAPI.Tests/V1/Factories/EntityFactoryTests.cs
+++ b/AddressesAPI.Tests/V1/Factories/EntityFactoryTests.cs
@@ -10,6 +10,7 @@ namespace AddressesAPI.Tests.V1.Factories
     public class EntityFactoryTests
     {
         private readonly Fixture _fixture = new Fixture();
+
         [Test]
         public void CanMapAnAddressEntityToDomain()
         {
@@ -23,6 +24,15 @@ namespace AddressesAPI.Tests.V1.Factories
                 {"HackneyGazetteerOutOfBoroughAddress", addressEntity.NeverExport }
             };
             address.ShouldBeEquivalentToExpectedObjectWithExceptions(addressEntity, exceptions);
+        }
+
+        [Test]
+        public void CanMapACrossReferenceEntityToDomain()
+        {
+            var crossReferenceEntity = _fixture.Create<CrossReference>();
+            var crossReference = crossReferenceEntity.ToDomain();
+
+            crossReference.ShouldBeEquivalentToExpectedObjectWithExceptions(crossReferenceEntity);
         }
     }
 }

--- a/AddressesAPI.Tests/V1/Gateways/CrossReferenceGatewayTest.cs
+++ b/AddressesAPI.Tests/V1/Gateways/CrossReferenceGatewayTest.cs
@@ -24,7 +24,7 @@ namespace AddressesAPI.Tests.V1.Gateways
         {
             var uprn = _faker.Random.Long();
 
-            var savedCrossRef = TestEfDataHelper.insertCrossReference(DatabaseContext, uprn);
+            var savedCrossRef = TestEfDataHelper.InsertCrossReference(DatabaseContext, uprn);
 
             var response = _classUnderTest.GetAddressCrossReference(uprn);
 

--- a/AddressesAPI.Tests/V1/Gateways/CrossReferenceGatewayTest.cs
+++ b/AddressesAPI.Tests/V1/Gateways/CrossReferenceGatewayTest.cs
@@ -1,0 +1,48 @@
+using System.Linq;
+using AddressesAPI.Tests.V1.Helper;
+using AddressesAPI.V1.Factories;
+using AddressesAPI.V1.Gateways;
+using Bogus;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace AddressesAPI.Tests.V1.Gateways
+{
+    public class CrossReferenceGatewayTest : DatabaseTests
+    {
+        private CrossReferencesGateway _classUnderTest { get; set; }
+        private readonly Faker _faker = new Faker();
+
+        [SetUp]
+        public void SetUp()
+        {
+            _classUnderTest = new CrossReferencesGateway(DatabaseContext);
+        }
+
+        [Test]
+        public void ItWillReturnAListOfCrossReferencesUsingAUprn()
+        {
+            var uprn = _faker.Random.Long();
+
+            var savedCrossRef = TestEfDataHelper.insertCrossReference(DatabaseContext, uprn);
+
+            var response = _classUnderTest.GetAddressCrossReference(uprn);
+
+            response.Should().NotBeNull();
+
+            response.First().UPRN.Should().Be(uprn);
+            response.First().Should().BeEquivalentTo(savedCrossRef.ToDomain());
+        }
+
+        [Test]
+        public void ItWillReturnAnEmptyListIfACrossRefCouldNotBeFound()
+        {
+            var uprn = _faker.Random.Long();
+
+            var response = _classUnderTest.GetAddressCrossReference(uprn);
+
+            response.Should().NotBeNull();
+            response.Count.Should().Be(0);
+        }
+    }
+}

--- a/AddressesAPI.Tests/V1/Helper/TestEfDatabaseHelper.cs
+++ b/AddressesAPI.Tests/V1/Helper/TestEfDatabaseHelper.cs
@@ -37,6 +37,19 @@ namespace AddressesAPI.Tests.V1.Helper
             return randomAddressRecord;
         }
 
+        public static CrossReference insertCrossReference(AddressesContext context, long uprn)
+        {
+            var fixture = new Fixture();
+            var crossRefRecord = fixture.Build<CrossReference>()
+                .With(cr => cr.UPRN, uprn)
+                .Create();
+
+            context.AddressCrossReferences.Add(crossRefRecord);
+            context.SaveChanges();
+
+            return crossRefRecord;
+        }
+
         private static string ReplaceEmptyStringWithNull(string request)
         {
             return request.Length == 0 ? null : request;

--- a/AddressesAPI.Tests/V1/Helper/TestEfDatabaseHelper.cs
+++ b/AddressesAPI.Tests/V1/Helper/TestEfDatabaseHelper.cs
@@ -37,7 +37,7 @@ namespace AddressesAPI.Tests.V1.Helper
             return randomAddressRecord;
         }
 
-        public static CrossReference insertCrossReference(AddressesContext context, long uprn)
+        public static CrossReference InsertCrossReference(AddressesContext context, long uprn)
         {
             var fixture = new Fixture();
             var crossRefRecord = fixture.Build<CrossReference>()

--- a/AddressesAPI/V1/Factories/EntityFactory.cs
+++ b/AddressesAPI/V1/Factories/EntityFactory.cs
@@ -1,4 +1,6 @@
 using AddressesAPI.V1.Domain;
+using AddressesAPI.V1.Infrastructure;
+using Address = AddressesAPI.V1.Domain.Address;
 
 namespace AddressesAPI.V1.Factories
 {
@@ -44,6 +46,19 @@ namespace AddressesAPI.V1.Factories
                 Town = addressEntity.Town,
                 UPRN = addressEntity.UPRN,
                 Postcode = addressEntity.Postcode,
+            };
+        }
+
+        public static AddressCrossReference ToDomain(this CrossReference crossReference)
+        {
+            return new AddressCrossReference
+            {
+                CrossRefKey = crossReference.CrossRefKey,
+                UPRN = crossReference.UPRN,
+                Code = crossReference.Code,
+                Name = crossReference.Name,
+                Value = crossReference.Value,
+                EndDate = crossReference?.EndDate
             };
         }
     }

--- a/AddressesAPI/V1/Gateways/CrossReferencesGateway.cs
+++ b/AddressesAPI/V1/Gateways/CrossReferencesGateway.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Linq;
+using AddressesAPI.V1.Domain;
+using AddressesAPI.V1.Factories;
+using AddressesAPI.V1.Infrastructure;
+
+namespace AddressesAPI.V1.Gateways
+{
+    public class CrossReferencesGateway : ICrossReferencesGateway
+    {
+        private readonly AddressesContext _addressesContext;
+        public CrossReferencesGateway(AddressesContext addressesContext)
+        {
+            _addressesContext = addressesContext;
+        }
+
+        public List<AddressCrossReference> GetAddressCrossReference(long uprn)
+        {
+            return _addressesContext.AddressCrossReferences
+                .Where(x => x.UPRN.Equals(uprn))
+                .Select(cr => cr.ToDomain()).ToList();
+        }
+    }
+}

--- a/AddressesAPI/V1/Gateways/ICrossReferencesGateway.cs
+++ b/AddressesAPI/V1/Gateways/ICrossReferencesGateway.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using AddressesAPI.V1.Domain;
+
+namespace AddressesAPI.V1.Gateways
+{
+    public interface ICrossReferencesGateway
+    {
+        public List<AddressCrossReference> GetAddressCrossReference(long uprn);
+    }
+}

--- a/AddressesAPI/V1/Infrastructure/CrossReference.cs
+++ b/AddressesAPI/V1/Infrastructure/CrossReference.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 
 namespace AddressesAPI.V1.Infrastructure
 {
-    [Table("hackney_xref")]
+    [Table("hackney_xref", Schema = "dbo")]
     public class CrossReference
     {
         [Column("xref_key")]


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/PA-390

## Describe this PR

### *What is the problem we're trying to solve*

As part of the plan to migrate the address data from SQL DB to a Postgres DB, we want to set up the gateway methods to retain the same functionality but using EF and Postgres.

### *What changes have we introduced*

The get address cross-references gateway functionality has been replicated using EF and Postgres.

It has been added to a separate gateway class as it connects with a different data set than the other two original gateway methods.

#### _Checklist_
- [X] Added tests to cover all new production code
- [X] Checked all code for possible refactoring
- [X] Code pipeline builds correctly