### PR TITLE
Address status searching should be case insensitive

### DIFF
--- a/AddressesAPI.Tests/V1/Gateways/AddressGatewayTest.cs
+++ b/AddressesAPI.Tests/V1/Gateways/AddressGatewayTest.cs
@@ -149,8 +149,10 @@ namespace AddressesAPI.Tests.V1.Gateways
         [TestCase("Historical", "Historical")]
         [TestCase("Provisional", "Provisional")]
         [TestCase("Alternative", "Alternative,Approved Preferred")]
+        [TestCase("alternative", "Alternative,Approved Preferred")]
         [TestCase("Historical", "Alternative,Approved Preferred,Historical")]
         [TestCase("Provisional", "Historical,Provisional")]
+        [TestCase("Provisional", "Historical,provisional")]
         public void WillSearchForAddressesWithStatus(string savedStatus, string statusSearchTerm)
         {
             var savedAddress = TestEfDataHelper.InsertAddress(DatabaseContext,

--- a/AddressesAPI/V1/Gateways/AddressesGateway.cs
+++ b/AddressesAPI/V1/Gateways/AddressesGateway.cs
@@ -71,7 +71,8 @@ namespace AddressesAPI.V1.Gateways
             var postcodeSearchTerm = GenerateSearchTerm(request.Postcode);
             var buildingNumberSearchTerm = GenerateSearchTerm(request.BuildingNumber);
             var streetSearchTerm = GenerateSearchTerm(request.Street);
-            var addressStatusSearchTerms = request.AddressStatus?.Split(',') ?? new[] { "Approved Preferred" };
+            var addressStatusSearchTerms = request.AddressStatus?.Split(',').Select(a => a.ToLower())
+                                           ?? new[] { "approved preferred" };
             var usageSearchTerms = request.UsagePrimary?.Split(',').Where(u => u != "Parent Shell").ToList();
             var usageCodeSearchTerms = request.UsageCode?.Split(',').ToList();
             var queryBase = _addressesContext.Addresses
@@ -81,7 +82,7 @@ namespace AddressesAPI.V1.Gateways
                             || EF.Functions.ILike(a.BuildingNumber, buildingNumberSearchTerm))
                 .Where(a => string.IsNullOrWhiteSpace(request.Street) ||
                             EF.Functions.ILike(a.Street.Replace(" ", ""), streetSearchTerm))
-                .Where(a => addressStatusSearchTerms == null || addressStatusSearchTerms.Contains(a.AddressStatus))
+                .Where(a => addressStatusSearchTerms == null || addressStatusSearchTerms.Contains(a.AddressStatus.ToLower()))
                 .Where(a => request.Uprn == null || a.UPRN == request.Uprn)
                 .Where(a => request.Usrn == null
                             || a.USRN == request.Usrn)


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

Searching address status is currently case sensitive, but it shouldn't be. This PR puts both the database field and search term to lower case before performing a comparison.
#### _Checklist_

- [x] Added tests to cover all new production code

