### PR TITLE
Increase db storage to 40GiB

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -63,7 +63,7 @@ module "postgres_db_production" {
   db_engine            = "postgres"
   db_engine_version    = "11.1"
   db_instance_class    = "db.t2.micro"
-  db_allocated_storage = 20
+  db_allocated_storage = 40
   maintenance_window   = "sun:10:00-sun:10:30"
   db_username          = data.aws_ssm_parameter.addresses_postgres_username.value
   db_password          = data.aws_ssm_parameter.addresses_postgres_db_password.value

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -1,6 +1,6 @@
-# INSTRUCTIONS: 
-# 1) ENSURE YOU POPULATE THE LOCALS 
-# 2) ENSURE YOU REPLACE ALL INPUT PARAMETERS, THAT CURRENTLY STATE 'ENTER VALUE', WITH VALID VALUES 
+# INSTRUCTIONS:
+# 1) ENSURE YOU POPULATE THE LOCALS
+# 2) ENSURE YOU REPLACE ALL INPUT PARAMETERS, THAT CURRENTLY STATE 'ENTER VALUE', WITH VALID VALUES
 # 3) YOUR CODE WOULD NOT COMPILE IF STEP NUMBER 2 IS NOT PERFORMED!
 # 4) ENSURE YOU CREATE A BUCKET FOR YOUR STATE FILE AND YOU ADD THE NAME BELOW - MAINTAINING THE STATE OF THE INFRASTRUCTURE YOU CREATE IS ESSENTIAL - FOR APIS, THE BUCKETS ALREADY EXIST
 # 5) THE VALUES OF THE COMMON COMPONENTS THAT YOU WILL NEED ARE PROVIDED IN THE COMMENTS
@@ -64,7 +64,7 @@ module "postgres_db_staging" {
   db_engine            = "postgres"
   db_engine_version    = "11.1"
   db_instance_class    = "db.t2.micro"
-  db_allocated_storage = 20
+  db_allocated_storage = 40
   maintenance_window   = "sun:10:00-sun:10:30"
   db_username          = data.aws_ssm_parameter.addresses_postgres_username.value
   db_password          = data.aws_ssm_parameter.addresses_postgres_db_password.value


### PR DESCRIPTION
The storage for the database was manually increased to allow for the number of addresses which need to be added. 
This PR includes this change to the terraform file so that the change doesn't get overridden.