### PR TITLE
Only non null values are included in JSON response

### DIFF
--- a/AddressesAPI.Tests/V1/E2ETests/SearchAddressIntegrationTests.cs
+++ b/AddressesAPI.Tests/V1/E2ETests/SearchAddressIntegrationTests.cs
@@ -115,19 +115,15 @@ namespace AddressesAPI.Tests.V1.E2ETests
             var response = await CallEndpointWithQueryParameters(queryString).ConfigureAwait(true);
             response.StatusCode.Should().Be(200);
 
-            var returnedAddress = await ConvertToResponseObject(response).ConfigureAwait(true);
-            returnedAddress.Data.Addresses.Count.Should().Be(1);
-            var receivedAddress = returnedAddress.Data.Addresses.First();
-            receivedAddress.Should().BeEquivalentTo(new AddressResponse
-            {
-                Line1 = addressDetails.Line1,
-                Line2 = addressDetails.Line2,
-                Line3 = addressDetails.Line3,
-                Line4 = addressDetails.Line4,
-                Town = addressDetails.Town,
-                Postcode = addressDetails.Postcode,
-                UPRN = addressDetails.UPRN
-            });
+            var data = await response.Content.ReadAsStringAsync().ConfigureAwait(true);
+            data.Should().BeEquivalentTo(
+                "{\"data\":" +
+                "{\"address\":[" +
+                    $"{{\"line1\":\"{addressDetails.Line1}\",\"line2\":\"{addressDetails.Line2}\"," +
+                    $"\"line3\":\"{addressDetails.Line3}\",\"line4\":\"{addressDetails.Line4}\"," +
+                    $"\"town\":\"{addressDetails.Town}\",\"postcode\":\"{addressDetails.Postcode}\"," +
+                    $"\"UPRN\":{addressDetails.UPRN}}}" +
+                "],\"page_count\":1,\"total_count\":1},\"statusCode\":200}");
         }
 
         [Test]

--- a/AddressesAPI/Startup.cs
+++ b/AddressesAPI/Startup.cs
@@ -18,6 +18,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
@@ -41,7 +42,11 @@ namespace AddressesAPI
                 .AddMvc()
                 .SetCompatibilityVersion(CompatibilityVersion.Version_3_0)
                 .AddNewtonsoftJson(options =>
-                    options.SerializerSettings.Converters.Add(new StringEnumConverter()))
+                    {
+                        options.SerializerSettings.Converters.Add(new StringEnumConverter());
+                        options.SerializerSettings.NullValueHandling = NullValueHandling.Ignore;
+                    }
+                )
                 .SetCompatibilityVersion(CompatibilityVersion.Version_3_0); ;
             services.AddApiVersioning(o =>
             {

--- a/AddressesAPI/V1/Boundary/Responses/Data/AddressResponse.cs
+++ b/AddressesAPI/V1/Boundary/Responses/Data/AddressResponse.cs
@@ -1,3 +1,6 @@
+using System.Text.Json.Serialization;
+using Newtonsoft.Json;
+
 namespace AddressesAPI.V1.Boundary.Responses
 {
     public class AddressResponse
@@ -9,6 +12,7 @@ namespace AddressesAPI.V1.Boundary.Responses
         public string Line4 { get; set; }
         public string Town { get; set; }
         public string Postcode { get; set; }
+        [JsonProperty("UPRN")]
         public long UPRN { get; set; }
 
         //Extra fields for Address detailed
@@ -83,7 +87,7 @@ namespace AddressesAPI.V1.Boundary.Responses
         /// <summary>
         /// Only included if format query parameter is set to detailed.
         /// </summary>
-        public bool PropertyShell { get; set; }
+        public bool? PropertyShell { get; set; }
         /// <summary>
         /// Only included if format query parameter is set to detailed.
         /// </summary>
@@ -91,42 +95,42 @@ namespace AddressesAPI.V1.Boundary.Responses
         /// <summary>
         /// Only included if format query parameter is set to detailed.
         /// </summary>
-        public double Easting { get; set; }
+        public double? Easting { get; set; }
         /// <summary>
         /// Only included if format query parameter is set to detailed.
         /// </summary>
-        public double Northing { get; set; }
+        public double? Northing { get; set; }
         /// <summary>
         /// Only included if format query parameter is set to detailed.
         /// </summary>
-        public double Longitude { get; set; }
+        public double? Longitude { get; set; }
         /// <summary>
         /// Only included if format query parameter is set to detailed.
         /// </summary>
-        public double Latitude { get; set; }
+        public double? Latitude { get; set; }
         /// <summary>
         /// Only included if format query parameter is set to detailed.
         /// </summary>
-        public int AddressStartDate { get; set; }
+        public int? AddressStartDate { get; set; }
         /// <summary>
         /// Only included if format query parameter is set to detailed.
         /// </summary>
-        public int AddressEndDate { get; set; }
+        public int? AddressEndDate { get; set; }
         /// <summary>
         /// Only included if format query parameter is set to detailed.
         /// </summary>
-        public int AddressChangeDate { get; set; }
+        public int? AddressChangeDate { get; set; }
         /// <summary>
         /// Only included if format query parameter is set to detailed.
         /// </summary>
-        public int PropertyStartDate { get; set; }
+        public int? PropertyStartDate { get; set; }
         /// <summary>
         /// Only included if format query parameter is set to detailed.
         /// </summary>
-        public int PropertyEndDate { get; set; }
+        public int? PropertyEndDate { get; set; }
         /// <summary>
         /// Only included if format query parameter is set to detailed.
         /// </summary>
-        public int PropertyChangeDate { get; set; }
+        public int? PropertyChangeDate { get; set; }
     }
 }

--- a/AddressesAPI/V1/Domain/Address.cs
+++ b/AddressesAPI/V1/Domain/Address.cs
@@ -20,18 +20,18 @@ namespace AddressesAPI.V1.Domain
         public string UsagePrimary { get; set; }
         public string UsageCode { get; set; }
         public string PlanningUseClass { get; set; }
-        public bool PropertyShell { get; set; }
+        public bool? PropertyShell { get; set; }
         public bool? HackneyGazetteerOutOfBoroughAddress { get; set; } //for LLPG results; should be null in results for NLPG
-        public double Easting { get; set; }
-        public double Northing { get; set; }
-        public double Longitude { get; set; }
-        public double Latitude { get; set; }
-        public int AddressStartDate { get; set; }
-        public int AddressEndDate { get; set; }
-        public int AddressChangeDate { get; set; }
-        public int PropertyStartDate { get; set; }
-        public int PropertyEndDate { get; set; }
-        public int PropertyChangeDate { get; set; }
+        public double? Easting { get; set; }
+        public double? Northing { get; set; }
+        public double? Longitude { get; set; }
+        public double? Latitude { get; set; }
+        public int? AddressStartDate { get; set; }
+        public int? AddressEndDate { get; set; }
+        public int? AddressChangeDate { get; set; }
+        public int? PropertyStartDate { get; set; }
+        public int? PropertyEndDate { get; set; }
+        public int? PropertyChangeDate { get; set; }
 
         // address simple fields
         public string Line1 { get; set; }


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

We only want to return fields which have a value in the json response.
This PR ensures UPRN is returned as caps as that is how consumers are currently expecting it to look.
It also makes all fields which are only in the detailed format nullable

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Code pipeline builds correctly
