### PR TITLE
Search postcode from begining

### DIFF
--- a/AddressesAPI.Tests/V1/Gateways/AddressGatewayTest.cs
+++ b/AddressesAPI.Tests/V1/Gateways/AddressGatewayTest.cs
@@ -100,6 +100,26 @@ namespace AddressesAPI.Tests.V1.Gateways
             addresses.First().Should().BeEquivalentTo(savedAddress.ToDomain());
         }
 
+        [TestCase("LE1 3TT", "E1")]
+        [TestCase("SW1 7YU", "W1 7")]
+        public void WillOnlyGetPostcodesWhichMatchAtTheStart(string savedPostcode, string postcodeSearch)
+        {
+            var savedAddress = TestEfDataHelper.InsertAddress(DatabaseContext,
+                request: new NationalAddress { Postcode = savedPostcode }
+            );
+            var request = new SearchParameters
+            {
+                Page = 1,
+                PageSize = 50,
+                Format = GlobalConstants.Format.Detailed,
+                Gazetteer = GlobalConstants.Gazetteer.Both,
+                Postcode = postcodeSearch
+            };
+            var (addresses, _) = _classUnderTest.SearchAddresses(request);
+
+            addresses.Count.Should().Be(0);
+        }
+
         [TestCase("123", "123")]
         [TestCase("123383833", "383")]
         public void WillSearchBuildingsNumbersForAMatch(string savedBuildingNumber, string buildingNumberSearch)

--- a/AddressesAPI.Tests/V1/Gateways/AddressGatewayTest.cs
+++ b/AddressesAPI.Tests/V1/Gateways/AddressGatewayTest.cs
@@ -85,7 +85,11 @@ namespace AddressesAPI.Tests.V1.Gateways
             var savedAddress = TestEfDataHelper.InsertAddress(DatabaseContext,
                 request: new NationalAddress { Postcode = savedPostcode }
                 );
-            TestEfDataHelper.InsertAddress(DatabaseContext);
+            var randomPostcode = $"NW{_faker.Random.Int(1, 9)} {_faker.Random.Int(1, 9)}TY";
+            TestEfDataHelper.InsertAddress(DatabaseContext, request: new NationalAddress
+            {
+                Postcode = randomPostcode
+            });
             var request = new SearchParameters
             {
                 Page = 1,

--- a/AddressesAPI/V1/Gateways/AddressesGateway.cs
+++ b/AddressesAPI/V1/Gateways/AddressesGateway.cs
@@ -2,13 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
 using AddressesAPI.V1.Domain;
 using AddressesAPI.V1.Factories;
 using AddressesAPI.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Query;
-using Microsoft.EntityFrameworkCore.Query.SqlExpressions;
 using Address = AddressesAPI.V1.Domain.Address;
 
 namespace AddressesAPI.V1.Gateways
@@ -68,7 +65,7 @@ namespace AddressesAPI.V1.Gateways
 
         private IQueryable<Infrastructure.Address> CompileBaseSearchQuery(SearchParameters request)
         {
-            var postcodeSearchTerm = GenerateSearchTerm(request.Postcode);
+            var postcodeSearchTerm = request.Postcode == null ? null : $"{request.Postcode.Replace(" ", "")}%";
             var buildingNumberSearchTerm = GenerateSearchTerm(request.BuildingNumber);
             var streetSearchTerm = GenerateSearchTerm(request.Street);
             var addressStatusSearchTerms = request.AddressStatus?.Split(',').Select(a => a.ToLower())


### PR DESCRIPTION
## Describe this PR
When searching by postcode, we only want to return an address if its postcode matches the search term from the start instead of anywhere in the postcode string.

For example, searching for E1 should match postcode E1 1JJ but not LE1 2RT.

Also, fixed a test which was failing sometimes because of randomly generated values.  I've partially hardcoded it now to prevent this.

#### _Checklist_

- [x] Added tests to cover all new production code
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly