### PR TITLE
Change ordering query to remove case statements

### DIFF
--- a/AddressesAPI/V1/Gateways/AddressesGateway.cs
+++ b/AddressesAPI/V1/Gateways/AddressesGateway.cs
@@ -50,16 +50,17 @@ namespace AddressesAPI.V1.Gateways
         private static IQueryable<Infrastructure.Address> OrderAddresses(IQueryable<Infrastructure.Address> query)
         {
             return query.OrderBy(a => a.Town)
-                .ThenBy(a => a.Postcode == null ? 1 : 0)
+                .ThenBy(a => a.Postcode == null)
                 .ThenBy(a => a.Postcode)
                 .ThenBy(a => a.Street)
-                .ThenBy(a => a.PaonStartNumber == null || a.PaonStartNumber == 0 ? 1 : 0)
+                .ThenBy(a => a.PaonStartNumber == null)
+                .ThenBy(a => a.PaonStartNumber == 0)
                 .ThenBy(a => a.PaonStartNumber)
-                .ThenBy(a => a.BuildingNumber == null ? 1 : 0)
+                .ThenBy(a => a.BuildingNumber == null)
                 .ThenBy(a => a.BuildingNumber)
-                .ThenBy(a => a.UnitNumber == null ? 1 : 0)
+                .ThenBy(a => a.UnitNumber == null)
                 .ThenBy(a => a.UnitNumber)
-                .ThenBy(a => a.UnitName == null ? 1 : 0)
+                .ThenBy(a => a.UnitName == null)
                 .ThenBy(a => a.UnitName);
         }
 


### PR DESCRIPTION
## Describe this PR

In Postgres a false value will order above a true value. So changing for ordering against `field == null ? 1 : 0` will have the same effect as ordering against `field == null` but will remove case statements from the resulting SQL query, hence speeding up the query.