### PR TITLE
Ignore .vscode files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ ipch/
 *.vssscc
 *.bak.*
 *.bak
+*.vscode
 
 #Tools
 _ReSharper.*


### PR DESCRIPTION
Adds the `.vscode` folder to the `.gitignore` file.

Any files saved in the .`vscode` folder (Created when building the project using VSCode) would be ignored and not committed

#### _Checklist_

- [X] Code pipeline builds correctly