### PR TITLE
Use dev-database container name in the seed database make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ migrate-dev-database:
 
 .PHONY: seed-dev-database
 seed-dev-database:
-	docker exec $$(docker ps -q --filter ancestor=dev-database) psql -d devdb -U postgres -f /var/seed-dev-data.sql
+	docker exec dev-database psql -d devdb -U postgres -f /var/seed-dev-data.sql
 
 
 .PHONY: lint


### PR DESCRIPTION
When running the `make seed-dev-database` command, docker errors with the following: `Error: No such container: psql`.

Running `docker ps -q --filter ancestor=dev-database` which makes up part of the make command above, returns nothing so it might be assuming that the `psql` command afterwards is the container name.

Not sure why the above `docker ps` command returns nothing but since we have a container name set up for the dev-database it might be better to use the container name in the `docker exec` command instead.

#### _Checklist_
- [X] Code pipeline builds correctly