### PR TITLE
Out of borough addresses

### DIFF
--- a/AddressesAPI.Tests/V1/Factories/EntityFactoryTests.cs
+++ b/AddressesAPI.Tests/V1/Factories/EntityFactoryTests.cs
@@ -21,7 +21,7 @@ namespace AddressesAPI.Tests.V1.Factories
             var exceptions = new Dictionary<string, object>
             {
                 {"CommercialOccupier", addressEntity.Organisation},
-                {"HackneyGazetteerOutOfBoroughAddress", addressEntity.NeverExport }
+                {"HackneyGazetteerOutOfBoroughAddress", addressEntity.OutOfBoroughAddress }
             };
             address.ShouldBeEquivalentToExpectedObjectWithExceptions(addressEntity, exceptions);
         }

--- a/AddressesAPI.Tests/V2/Factories/EntityFactoryTests.cs
+++ b/AddressesAPI.Tests/V2/Factories/EntityFactoryTests.cs
@@ -1,8 +1,10 @@
 using System.Collections.Generic;
 using AddressesAPI.Infrastructure;
 using AddressesAPI.Tests.V2.Helper;
+using AddressesAPI.V2;
 using AddressesAPI.V2.Factories;
 using AutoFixture;
+using FluentAssertions;
 using NUnit.Framework;
 
 namespace AddressesAPI.Tests.V2.Factories
@@ -21,9 +23,23 @@ namespace AddressesAPI.Tests.V2.Factories
             var exceptions = new Dictionary<string, object>
             {
                 {"CommercialOccupier", addressEntity.Organisation},
-                {"HackneyGazetteerOutOfBoroughAddress", addressEntity.NeverExport }
+                {"OutOfBoroughAddress", false}
             };
             address.ShouldBeEquivalentToExpectedObjectWithExceptions(addressEntity, exceptions);
+        }
+
+        [TestCase("Hackney", false, false)]
+        [TestCase("Hackney", true, true)]
+        [TestCase("National", true, true)]
+        [TestCase("National", false, true)]
+        public void CorrectlySetsOutOfBoroughProperty(string gazetteer, bool dbOutOfBoroughValue, bool expectedOutOfBorough)
+        {
+            var domain = _fixture.Build<Address>()
+                .With(a => a.Gazetteer, gazetteer)
+                .With(a => a.OutOfBoroughAddress, dbOutOfBoroughValue)
+                .Create();
+            var response = domain.ToDomain();
+            response.OutOfBoroughAddress.Should().Be(expectedOutOfBorough);
         }
 
         [Test]

--- a/AddressesAPI.Tests/V2/SearchAddressRequestTests.cs
+++ b/AddressesAPI.Tests/V2/SearchAddressRequestTests.cs
@@ -40,44 +40,30 @@ namespace AddressesAPI.Tests.V2
         }
         #endregion
 
-        #region HackneyGazetteerOutOfBoroughAddress
-        [Test] //Gazetteer -> no input, HGOBAddress -> no input
-        public void GivenNoInputValueForGazetteerAndHackneyGazetteerOutOfBoroughAddressParameters_WhenSearchAddressRequestObjectIsCreated_GazetteerIsSetToItsDefaultAndHackneyGazetteerOutOfBoroughAddressIsSetToNullBasedOnThat()
+        #region OutOfBoroughAddress
+        [Test]
+        public void GivenNoInputValueForOutOfBoroughAddressParameter_WhenSearchAddressRequestObjectIsCreated_OutOfBoroughAddressIsSetToTrue()
         {
             var classUnderTest = new SearchAddressRequest();
-            classUnderTest.HackneyGazetteerOutOfBoroughAddress.Should().BeNull();
-        }
-
-        [Test] //Gazetteer = Both, HGOBAddress -> no input
-        public void GivenGazetteerValueBothAndNoInputForHackneyGazetteerOutOfBoroughAddress_WhenSearchAddressRequestObjectIsCreated_HackneyGazetteerOutOfBoroughAddressIsSetToNull()
-        {
-            var classUnderTest = new SearchAddressRequest { Gazetteer = _bothGazetteers };
-            classUnderTest.HackneyGazetteerOutOfBoroughAddress.Should().BeNull();
-        }
-
-        [Test] //Gazetteer = Local, HGOBAddress -> no input
-        public void GivenGazetteerValueLocalAndNoInputForHackneyGazetteerOutOfBoroughAddress_WhenSearchAddressRequestObjectIsCreated_HackneyGazetteerOutOfBoroughAddressIsSetToFalse()
-        {
-            var classUnderTest = new SearchAddressRequest { Gazetteer = _localGazetteer };
-            classUnderTest.HackneyGazetteerOutOfBoroughAddress.Should().BeFalse();
+            classUnderTest.OutOfBoroughAddress.Should().BeTrue();
         }
 
         [TestCase("Both", false)]
         [TestCase("Both", true)]
         [TestCase("Local", false)]
         [TestCase("Local", true)]
-        public void GivenAHackneyGazetteerOutOfBoroughAddressInputValueAndAnyGazetteerValue_WhenSearchAddressRequestObjectIsCreated_HackneyGazetteerOutOfBoroughAddressIsSetToWhateverItsInputWas(string gazetteer, bool? hackneyGazetteerOutOfBoroughAddress)
+        public void GivenAHackneyGazetteerOutOfBoroughAddressInputValueAndAnyGazetteerValue_WhenSearchAddressRequestObjectIsCreated_HackneyGazetteerOutOfBoroughAddressIsSetToWhateverItsInputWas(string gazetteer, bool hackneyGazetteerOutOfBoroughAddress)
         {
-            var classUnderTest = new SearchAddressRequest { Gazetteer = gazetteer, HackneyGazetteerOutOfBoroughAddress = hackneyGazetteerOutOfBoroughAddress };
-            classUnderTest.HackneyGazetteerOutOfBoroughAddress.Should().Be(hackneyGazetteerOutOfBoroughAddress);
+            var classUnderTest = new SearchAddressRequest { Gazetteer = gazetteer, OutOfBoroughAddress = hackneyGazetteerOutOfBoroughAddress };
+            classUnderTest.OutOfBoroughAddress.Should().Be(hackneyGazetteerOutOfBoroughAddress);
         }
 
         [TestCase(true)]
         [TestCase(false)]
-        public void GivenNoInputForGazetteerAndInputValueForHackneyGazetteerOutOfBoroughAddress_WhenSearchAddressRequestObjectIsCreated_HackneyGazetteerOutOfBoroughAddressIsSetToWhateverItsInputWas(bool? hackneyGazetteerOutOfBoroughAddress)
+        public void GivenNoInputForGazetteerAndInputValueForHackneyGazetteerOutOfBoroughAddress_WhenSearchAddressRequestObjectIsCreated_HackneyGazetteerOutOfBoroughAddressIsSetToWhateverItsInputWas(bool hackneyGazetteerOutOfBoroughAddress)
         {
-            var classUnderTest = new SearchAddressRequest { HackneyGazetteerOutOfBoroughAddress = hackneyGazetteerOutOfBoroughAddress };
-            classUnderTest.HackneyGazetteerOutOfBoroughAddress.Should().Be(hackneyGazetteerOutOfBoroughAddress);
+            var classUnderTest = new SearchAddressRequest { OutOfBoroughAddress = hackneyGazetteerOutOfBoroughAddress };
+            classUnderTest.OutOfBoroughAddress.Should().Be(hackneyGazetteerOutOfBoroughAddress);
         }
         #endregion
     }

--- a/AddressesAPI/Infrastructure/Address.cs
+++ b/AddressesAPI/Infrastructure/Address.cs
@@ -112,7 +112,7 @@ namespace AddressesAPI.Infrastructure
         public string PlanningUseClass { get; set; }
 
         [Column("neverexport")]
-        public bool NeverExport { get; set; }
+        public bool OutOfBoroughAddress { get; set; }
 
         [Column("longitude")]
         public double Longitude { get; set; }

--- a/AddressesAPI/V1/Factories/EntityFactory.cs
+++ b/AddressesAPI/V1/Factories/EntityFactory.cs
@@ -29,7 +29,7 @@ namespace AddressesAPI.V1.Factories
                 UsageCode = addressEntity.UsageCode,
                 PlanningUseClass = addressEntity.PlanningUseClass,
                 PropertyShell = addressEntity.PropertyShell,
-                HackneyGazetteerOutOfBoroughAddress = addressEntity.NeverExport,
+                HackneyGazetteerOutOfBoroughAddress = addressEntity.OutOfBoroughAddress,
                 Easting = addressEntity.Easting,
                 Northing = addressEntity.Northing,
                 Longitude = addressEntity.Longitude,

--- a/AddressesAPI/V1/Gateways/AddressesGateway.cs
+++ b/AddressesAPI/V1/Gateways/AddressesGateway.cs
@@ -94,7 +94,7 @@ namespace AddressesAPI.V1.Gateways
                             || EF.Functions.ILike(a.Gazetteer, request.Gazetteer.ToString())
                             )
                 .Where(a => request.HackneyGazetteerOutOfBoroughAddress == null ||
-                            request.HackneyGazetteerOutOfBoroughAddress == a.NeverExport);
+                            request.HackneyGazetteerOutOfBoroughAddress == a.OutOfBoroughAddress);
             return queryBase;
         }
 

--- a/AddressesAPI/V2/Boundary/Requests/SearchAddressRequest.cs
+++ b/AddressesAPI/V2/Boundary/Requests/SearchAddressRequest.cs
@@ -9,12 +9,9 @@ namespace AddressesAPI.V2.Boundary.Requests
     /// </summary>
     public class SearchAddressRequest
     {
-        private string _gazetteer;
-
         public SearchAddressRequest()
         {
             AddressStatus = "approved preferred";
-            Gazetteer = GlobalConstants.Gazetteer.Both.ToString();
         }
 
         /// <summary>
@@ -37,24 +34,7 @@ namespace AddressesAPI.V2.Boundary.Requests
         /// <summary>
         /// LOCAL/NATIONAL/BOTH (Defaults to LOCAL)
         /// </summary>
-        public string Gazetteer
-        {
-            get => _gazetteer;
-            set
-            {
-                //This logic needs reworking
-                _gazetteer = value;
-
-                if (_gazetteer == GlobalConstants.Gazetteer.Hackney.ToString())
-                {
-                    HackneyGazetteerOutOfBoroughAddress = false;
-                }
-                else if (_gazetteer == GlobalConstants.Gazetteer.Both.ToString())
-                {
-                    HackneyGazetteerOutOfBoroughAddress = null;
-                }
-            }
-        }
+        public string Gazetteer { get; set; } = GlobalConstants.Gazetteer.Both.ToString();
 
         /// <summary>
         /// Filter by UPRN (unique property reference number - unique identifier of the BLPU (Basic Land and Property Unit); a UPRN can have more than one LPI/address. )
@@ -110,7 +90,8 @@ namespace AddressesAPI.V2.Boundary.Requests
         ///precedence over the national gazetteer
         ///version.
         /// </summary>
-        public bool? HackneyGazetteerOutOfBoroughAddress { get; set; }
+        [FromQuery(Name = "out_of_borough")]
+        public bool OutOfBoroughAddress { get; set; } = true;
 
         /// <summary>
         /// Page defaults to 1 as paging is 1 index based not 0 index based

--- a/AddressesAPI/V2/Domain/SearchParameters.cs
+++ b/AddressesAPI/V2/Domain/SearchParameters.cs
@@ -12,7 +12,7 @@ namespace AddressesAPI.V2.Domain
         public string UsageCode { get; set; }
         public GlobalConstants.Format Format { get; set; }
         public string AddressStatus { get; set; }
-        public bool? HackneyGazetteerOutOfBoroughAddress { get; set; }
+        public bool OutOfBoroughAddress { get; set; }
         public int Page { get; set; }
         public int PageSize { get; set; }
     }

--- a/AddressesAPI/V2/Factories/EntityFactory.cs
+++ b/AddressesAPI/V2/Factories/EntityFactory.cs
@@ -1,4 +1,5 @@
 
+using System;
 using AddressesAPI.Infrastructure;
 using AddressesAPI.V2.Domain;
 using Address = AddressesAPI.V2.Domain.Address;
@@ -30,7 +31,8 @@ namespace AddressesAPI.V2.Factories
                 UsageCode = addressEntity.UsageCode,
                 PlanningUseClass = addressEntity.PlanningUseClass,
                 PropertyShell = addressEntity.PropertyShell,
-                OutOfBoroughAddress = addressEntity.NeverExport,
+                OutOfBoroughAddress = addressEntity.Gazetteer.Equals("national", StringComparison.InvariantCultureIgnoreCase)
+                    || addressEntity.OutOfBoroughAddress,
                 Easting = addressEntity.Easting,
                 Northing = addressEntity.Northing,
                 Longitude = addressEntity.Longitude,

--- a/AddressesAPI/V2/Gateways/AddressesGateway.cs
+++ b/AddressesAPI/V2/Gateways/AddressesGateway.cs
@@ -80,23 +80,25 @@ namespace AddressesAPI.V2.Gateways
                             || EF.Functions.ILike(a.BuildingNumber, buildingNumberSearchTerm))
                 .Where(a => string.IsNullOrWhiteSpace(request.Street) ||
                             EF.Functions.ILike(a.Street.Replace(" ", ""), streetSearchTerm))
-                .Where(a => addressStatusSearchTerms == null || addressStatusSearchTerms.Contains(a.AddressStatus.ToLower()))
+                .Where(a => addressStatusSearchTerms == null ||
+                            addressStatusSearchTerms.Contains(a.AddressStatus.ToLower()))
                 .Where(a => request.Uprn == null || a.UPRN == request.Uprn)
                 .Where(a => request.Usrn == null
                             || a.USRN == request.Usrn)
                 .Where(a => (usageSearchTerms == null || !usageSearchTerms.Any())
                             || usageSearchTerms.Contains(a.UsagePrimary))
                 .WhereAny(usageCodeSearchTerms?.Select(u =>
-                        (Expression<Func<Infrastructure.Address, bool>>) (x =>
+                        (Expression<Func<Address, bool>>) (x =>
                             EF.Functions.ILike(x.UsageCode, $"%{u}%")))
                     .ToArray())
                 .Where(a => request.Gazetteer == GlobalConstants.Gazetteer.Both
                             || EF.Functions.ILike(a.Gazetteer, request.Gazetteer.ToString())
                             || request.Gazetteer == GlobalConstants.Gazetteer.Hackney
-                                && EF.Functions.ILike(a.Gazetteer, "local")
-                            )
-                .Where(a => request.HackneyGazetteerOutOfBoroughAddress == null ||
-                            request.HackneyGazetteerOutOfBoroughAddress == a.OutOfBoroughAddress);
+                            && EF.Functions.ILike(a.Gazetteer, "local")
+                )
+                .Where(a => request.OutOfBoroughAddress
+                            || !(EF.Functions.ILike(a.Gazetteer, "national") || a.OutOfBoroughAddress)
+                );
             return queryBase;
         }
 

--- a/AddressesAPI/V2/Gateways/AddressesGateway.cs
+++ b/AddressesAPI/V2/Gateways/AddressesGateway.cs
@@ -96,7 +96,7 @@ namespace AddressesAPI.V2.Gateways
                                 && EF.Functions.ILike(a.Gazetteer, "local")
                             )
                 .Where(a => request.HackneyGazetteerOutOfBoroughAddress == null ||
-                            request.HackneyGazetteerOutOfBoroughAddress == a.NeverExport);
+                            request.HackneyGazetteerOutOfBoroughAddress == a.OutOfBoroughAddress);
             return queryBase;
         }
 

--- a/AddressesAPI/V2/UseCase/SearchAddressUseCase.cs
+++ b/AddressesAPI/V2/UseCase/SearchAddressUseCase.cs
@@ -62,7 +62,7 @@ namespace AddressesAPI.V2.UseCase
                 PageSize = request.PageSize,
                 UsageCode = request.usageCode,
                 UsagePrimary = request.usagePrimary,
-                HackneyGazetteerOutOfBoroughAddress = request.HackneyGazetteerOutOfBoroughAddress
+                OutOfBoroughAddress = request.OutOfBoroughAddress
             };
         }
     }

--- a/V2Changelog.md
+++ b/V2Changelog.md
@@ -6,7 +6,7 @@
 These changes will be relevent to both address endpoints
 1. The `Approved Preferred` option of the `addressStatus` property is changing to `Approved`. Making the new possible values:
 ```[ Approved, Historial, Alternative, Provisional ]```.
-2. The `hackneyGazetteerOutOfBoroughAddress` property has been replaced with the `outOfBoroughAddress` property, and denotes whether or not, an address is within the hackney borough.
+2. The `hackneyGazetteerOutOfBoroughAddress` property has been replaced with the `outOfBoroughAddress` property, and denotes whether or not, an address is within the borough of hackney .
 
 ## Changes to the get single address endpoint
 `/api/v2/addresses/{addressKey}`
@@ -80,6 +80,7 @@ Going forward they will look like:
   ]
 }
 ```
+4. There is a new query parameter `out_of_borough` which will toggle whether or not to include addresses which are outside of the borough of Hackney. The default setting for this parameter is `true` which will return all addresses, you can set `out_of_borough=false` if you wish to only receive addresses within Hackney.
 
 # Properties
 ## Get cross references for a propery


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/PA-403

## Describe this PR

### *What is the problem we're trying to solve*

The current `hackneyGazeteerOutOfBoroughAddress` query parameter doesn't work as expected, it is also a little complicated. In order to simplify the concept, we are introducing an `outOfBorough` query parameter, which toggles whether or not to include out of borough addresses. It can be used in conjunction with the gazetteer query parameter to achieve the aim of the previous parameter. The default is true.

### *What changes have we introduced*

This PR adds the query parameter and removes or alters the logic from the previous parameter. 
It also changes the value of the `OutOfBoroughAddress` property on the response object to always be `true` if an address is in the national gazetteer.

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

