### PR TITLE
If include parent shells is set to false, exclude them

### DIFF
--- a/AddressesAPI.Tests/V2/Gateways/AddressGatewayTest.cs
+++ b/AddressesAPI.Tests/V2/Gateways/AddressGatewayTest.cs
@@ -432,7 +432,7 @@ namespace AddressesAPI.Tests.V2.Gateways
         #region parentShells
 
         [Test]
-        public void IfSetToExcludeParentShellsWillOnlyReturnsResultOfSearch()
+        public void IfSetToExcludeParentShellsWillOnlyReturnsResultsOfSearch()
         {
             var parentShell = TestEfDataHelper.InsertAddress(DatabaseContext);
             var addressToMatch = TestEfDataHelper.InsertAddress(DatabaseContext,
@@ -506,6 +506,32 @@ namespace AddressesAPI.Tests.V2.Gateways
             addresses.Should().ContainEquivalentOf(addressToMatch.ToDomain());
             addresses.Should().ContainEquivalentOf(parentShell.ToDomain());
             addresses.Should().ContainEquivalentOf(grandParentShell.ToDomain());
+        }
+
+        [TestCase("E8 7JH")]
+        [TestCase("N1 5TH")]
+        public void IfSetToExcludeParentShellsWillNotReturnAnyParentShells(string postcode)
+        {
+            var parentShell = TestEfDataHelper.InsertAddress(DatabaseContext,
+                request: new NationalAddress { PropertyShell = true, Postcode = postcode }
+            );
+            var notAParentShell = TestEfDataHelper.InsertAddress(DatabaseContext,
+                request: new NationalAddress { PropertyShell = false, Postcode = postcode }
+            );
+
+            var request = new SearchParameters
+            {
+                Page = 1,
+                PageSize = 50,
+                Format = GlobalConstants.Format.Detailed,
+                Gazetteer = GlobalConstants.Gazetteer.Both,
+                Postcode = postcode,
+                IncludeParentShells = false
+            };
+            var (addresses, _) = _classUnderTest.SearchAddresses(request);
+
+            addresses.Count.Should().Be(1);
+            addresses.Should().ContainEquivalentOf(notAParentShell.ToDomain());
         }
 
         #endregion

--- a/AddressesAPI.Tests/V2/Helper/TestEfDatabaseHelper.cs
+++ b/AddressesAPI.Tests/V2/Helper/TestEfDatabaseHelper.cs
@@ -36,6 +36,7 @@ namespace AddressesAPI.Tests.V2.Helper
             if (request?.Line3 != null) randomAddressRecord.Line3 = request.Line3;
             if (request?.Line4 != null) randomAddressRecord.Line4 = request.Line4;
             randomAddressRecord.ParentUPRN = (request?.ParentUPRN).GetValueOrDefault() == 0 ? null : request.ParentUPRN;
+            randomAddressRecord.PropertyShell = request?.PropertyShell ?? false;
 
             context.NationalAddresses.Add(randomAddressRecord);
             context.SaveChanges();

--- a/AddressesAPI/V2/Gateways/AddressesGateway.cs
+++ b/AddressesAPI/V2/Gateways/AddressesGateway.cs
@@ -129,6 +129,7 @@ namespace AddressesAPI.V2.Gateways
                         (Expression<Func<Address, bool>>) (x =>
                             EF.Functions.ILike(x.UsageCode, $"%{u}%")))
                     .ToArray())
+                .Where(a => request.IncludeParentShells || !a.PropertyShell)
                 .Where(a => request.Gazetteer == GlobalConstants.Gazetteer.Both
                             || EF.Functions.ILike(a.Gazetteer, request.Gazetteer.ToString())
                             || request.Gazetteer == GlobalConstants.Gazetteer.Hackney


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/PA-402

## Describe this PR

### *What is the problem we're trying to solve*

When the include_parent_shell flag is set to false, parent shells should be excluded from the list of addresses returned.

### *What changes have we introduced*

If an address has a value of `true` for `propertyShell` in the database then exclude it from the set of results if `include_parent_shell` flag is set to false.

#### _Checklist_

- [x] Added tests to cover all new production code
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly
