### PR TITLE
Search addresses by cross reference

### DIFF
--- a/AddressesAPI.Tests/V2/Gateways/AddressGatewayTest.cs
+++ b/AddressesAPI.Tests/V2/Gateways/AddressGatewayTest.cs
@@ -429,17 +429,29 @@ namespace AddressesAPI.Tests.V2.Gateways
         }
 
         [Test]
-        public void WillSearchForAddressesUsingACrossReference()
+        public void WillSearchForAllAddressesUsingForACrossReference()
         {
             TestEfDataHelper.InsertAddress(DatabaseContext);
 
-            var uprn = _faker.Random.Long(10000000, 99999999);
+            //--- Cross reference for address one
+            var uprnOne = _faker.Random.Long(10000000, 99999999);
 
-            var savedAddress = TestEfDataHelper.InsertAddress(DatabaseContext,
-                request: new NationalAddress { UPRN = uprn }
+            var addressOne = TestEfDataHelper.InsertAddress(DatabaseContext,
+                request: new NationalAddress { UPRN = uprnOne }
             );
 
-            TestEfDataHelper.InsertCrossReference(DatabaseContext, uprn,
+            TestEfDataHelper.InsertCrossReference(DatabaseContext, uprnOne,
+                new CrossReference { Code = "TAXES", Value = "TestValue" }
+            );
+
+            //--- Cross reference for address two
+            var uprnTwo = _faker.Random.Long(10000000, 99999999);
+
+            var addressTwo = TestEfDataHelper.InsertAddress(DatabaseContext,
+                request: new NationalAddress { UPRN = uprnTwo }
+            );
+
+            TestEfDataHelper.InsertCrossReference(DatabaseContext, uprnTwo,
                 new CrossReference { Code = "TAXES", Value = "TestValue" }
             );
 
@@ -455,8 +467,9 @@ namespace AddressesAPI.Tests.V2.Gateways
 
             var (addresses, _) = _classUnderTest.SearchAddresses(request);
 
-            addresses.Count.Should().Be(1);
-            addresses.First().Should().BeEquivalentTo(savedAddress.ToDomain());
+            addresses.Count.Should().Be(2);
+            addresses.Should().ContainEquivalentOf(addressOne.ToDomain());
+            addresses.Should().ContainEquivalentOf(addressTwo.ToDomain());
         }
         #endregion
 

--- a/AddressesAPI.Tests/V2/Helper/TestEfDatabaseHelper.cs
+++ b/AddressesAPI.Tests/V2/Helper/TestEfDatabaseHelper.cs
@@ -44,19 +44,21 @@ namespace AddressesAPI.Tests.V2.Helper
 
         public static CrossReference InsertCrossReference(AddressesContext context, long uprn, CrossReference record = null)
         {
-            if (record == null)
-            {
-                var fixture = new Fixture();
-                record = fixture.Build<CrossReference>()
-                    .With(cr => cr.UPRN, uprn)
-                    .Create();
-            }
+            var fixture = new Fixture();
+            var randomCrossReference = fixture.Build<CrossReference>()
+                .With(cr => cr.UPRN, uprn)
+                .Create();
 
-            record.UPRN = uprn;
-            context.AddressCrossReferences.Add(record);
+            if (record?.UPRN != null && record.UPRN != 0) randomCrossReference.UPRN = record.UPRN;
+            if (record?.CrossRefKey != null) randomCrossReference.CrossRefKey = record.CrossRefKey;
+            if (record?.Code != null) randomCrossReference.Code = record.Code;
+            if (record?.Name != null) randomCrossReference.Name = record.Name;
+            if (record?.Value != null) randomCrossReference.Value = record.Value;
+            if (record?.EndDate != null) randomCrossReference.EndDate = record.EndDate;
+
+            context.AddressCrossReferences.Add(randomCrossReference);
             context.SaveChanges();
-
-            return record;
+            return randomCrossReference;
         }
 
         private static string ReplaceEmptyStringWithNull(string request)

--- a/AddressesAPI.Tests/V2/UseCase/SearchAddressUseCaseTest.cs
+++ b/AddressesAPI.Tests/V2/UseCase/SearchAddressUseCaseTest.cs
@@ -55,7 +55,9 @@ namespace AddressesAPI.Tests.V2.UseCase
                 UPRN = _faker.Random.Long(0, 9999999999),
                 USRN = _faker.Random.Int(0, 9999999),
                 IncludeParentShells = _faker.Random.Bool(),
-                OutOfBoroughAddress = _faker.Random.Bool()
+                OutOfBoroughAddress = _faker.Random.Bool(),
+                CrossRefCode = "123DEF",
+                CrossRefValue = "20000"
             };
             _fakeGateway.Setup(s => s.SearchAddresses(It.Is<SearchParameters>(
                     x => x.Format == GlobalConstants.Format.Detailed
@@ -71,7 +73,9 @@ namespace AddressesAPI.Tests.V2.UseCase
                          && x.UsageCode == request.UsageCode
                          && x.UsagePrimary == request.UsagePrimary
                          && x.IncludeParentShells == request.IncludeParentShells
-                         && x.OutOfBoroughAddress == request.OutOfBoroughAddress)))
+                         && x.OutOfBoroughAddress == request.OutOfBoroughAddress
+                         && x.CrossRefCode == request.CrossRefCode
+                         && x.CrossRefValue == request.CrossRefValue)))
                 .Returns((new List<Address>(), 1)).Verifiable();
 
             _classUnderTest.ExecuteAsync(request);

--- a/AddressesAPI.Tests/V2/UseCase/SearchAddressValidatorTests.cs
+++ b/AddressesAPI.Tests/V2/UseCase/SearchAddressValidatorTests.cs
@@ -247,6 +247,15 @@ namespace AddressesAPI.Tests.V2.UseCase
             _classUnderTest.ShouldHaveValidationErrorFor(x => x.RequestFields, request).WithErrorMessage("Invalid properties have been provided.");
         }
 
+        [TestCase("cross_ref_code", "cross_ref_value", "postcode", "RM3 0FS")]
+        public void GivenValidFilterParametersContainingUnderscores_WhenCallingValidation_ItReturnsNoErrors(string queryParameter1, string queryParameter2, string queryParameter3, string postcode)
+        {
+            var queryStringParameters = new List<string>() { queryParameter1, queryParameter2, queryParameter3 };
+            var request = new SearchAddressRequest() { Postcode = postcode, RequestFields = queryStringParameters };
+
+            _classUnderTest.ShouldNotHaveValidationErrorFor(x => x.RequestFields, request);
+        }
+
         #endregion
         #region Request object validation
 
@@ -346,6 +355,21 @@ namespace AddressesAPI.Tests.V2.UseCase
         {
             var request = new SearchAddressRequest() { BuildingNumber = buildingNumber };
             _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage("You must provide at least one of (uprn, usrn, postcode), when gazetteer is 'both'.");
+        }
+
+        [TestCase("TESTCD", "E5 9TT")]
+        public void GivenARequestWithACrossRefCode_ButNoCrossRefValueIsProvided_WhenCallingValidation_ItReturnsAnError(string queryParameter1, string postcode)
+        {
+            var request = new SearchAddressRequest() { Postcode = postcode, CrossRefCode = queryParameter1 };
+            _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage("You must provide both the code and a value, when searching by a cross reference");
+        }
+
+        [TestCase("123XYZ", "450000", "E5 9TT")]
+        [TestCase(null, null, "E5 9TT")]
+        public void GivenARequestWithCrossRefCodeAndACrossRefValue_BothPresentOrBothAbsent_WhenCallingValidation_ItReturnsNoError(string crossRefCode, string value, string postcode)
+        {
+            var request = new SearchAddressRequest() { Postcode = postcode, CrossRefCode = crossRefCode, CrossRefValue = value };
+            _classUnderTest.TestValidate(request).ShouldNotHaveError();
         }
 
         #endregion

--- a/AddressesAPI.Tests/V2/UseCase/SearchAddressValidatorTests.cs
+++ b/AddressesAPI.Tests/V2/UseCase/SearchAddressValidatorTests.cs
@@ -248,6 +248,7 @@ namespace AddressesAPI.Tests.V2.UseCase
         }
 
         [TestCase("cross_ref_code", "cross_ref_value", "postcode", "RM3 0FS")]
+        [TestCase("include_parent_shells", "address_status", "postcode", "E3 1QW")]
         public void GivenValidFilterParametersContainingUnderscores_WhenCallingValidation_ItReturnsNoErrors(string queryParameter1, string queryParameter2, string queryParameter3, string postcode)
         {
             var queryStringParameters = new List<string>() { queryParameter1, queryParameter2, queryParameter3 };

--- a/AddressesAPI/V2/Boundary/Requests/SearchAddressRequest.cs
+++ b/AddressesAPI/V2/Boundary/Requests/SearchAddressRequest.cs
@@ -102,6 +102,18 @@ namespace AddressesAPI.V2.Boundary.Requests
         public bool IncludeParentShells { get; set; } = false;
 
         /// <summary>
+        /// Filter addresses by a specific cross reference. Must be used together with `cross_ref_value`.
+        /// </summary>
+        [FromQuery(Name = "cross_ref_code")]
+        public string CrossRefCode { get; set; }
+
+        /// <summary>
+        /// Filter addresses by a specific cross reference. Must be used together with `cross_ref_code`.
+        /// </summary>
+        [FromQuery(Name = "cross_ref_value")]
+        public string CrossRefValue { get; set; }
+
+        /// <summary>
         /// Page defaults to 1 as paging is 1 index based not 0 index based
         /// </summary>
         public int Page { get; set; } = 1;

--- a/AddressesAPI/V2/Domain/SearchParameters.cs
+++ b/AddressesAPI/V2/Domain/SearchParameters.cs
@@ -16,6 +16,8 @@ namespace AddressesAPI.V2.Domain
         public IEnumerable<string> AddressStatus { get; set; }
         public bool OutOfBoroughAddress { get; set; }
         public bool IncludeParentShells { get; set; }
+        public string CrossRefCode { get; set; }
+        public string CrossRefValue { get; set; }
         public int Page { get; set; }
         public int PageSize { get; set; }
     }

--- a/AddressesAPI/V2/UseCase/SearchAddressUseCase.cs
+++ b/AddressesAPI/V2/UseCase/SearchAddressUseCase.cs
@@ -63,7 +63,9 @@ namespace AddressesAPI.V2.UseCase
                 UsageCode = request.UsageCode,
                 UsagePrimary = request.UsagePrimary,
                 OutOfBoroughAddress = request.OutOfBoroughAddress,
-                IncludeParentShells = request.IncludeParentShells
+                IncludeParentShells = request.IncludeParentShells,
+                CrossRefCode = request.CrossRefCode,
+                CrossRefValue = request.CrossRefValue
             };
         }
     }

--- a/V2Changelog.md
+++ b/V2Changelog.md
@@ -82,13 +82,10 @@ Going forward they will look like:
 5. There is a new query parameter `out_of_borough` which will toggle whether or not to include addresses which are outside of the borough of Hackney. The default setting for this parameter is `true` which will return all addresses, you can set `out_of_borough=false` if you wish to only receive addresses within Hackney.
 6. There is a new query parameter `include_parent_shells` which wll toggle whether or not to include the parent shells of addresses which are returned. If it is set to true, the endpoint will return all addresses which would be returned normally plus any parent shells and parents of parent shells and so on.
 An example of a parent shell would be a house converted into flats, each flat in the house would have it's own address (e.g. 1st Floor Flat, 5 Hackney Avenue) and then it's parent shell would be the address of the house (e.g. 5 Hackney Avenue).
+7. Two new optional query parameters have been added to allow a user to filter addresses by a specific cross reference. These are `cross_ref_code` and `cross_ref_value`. If filtering by a cross reference, both must be supplied i.e You cannot supply just a `cross_ref_code`. If only one has been supplied, the endpoint will return 400 (Bad Request) error. When both are given, the endpoint will return all addresses that match the cross reference given.
 
 # Properties
-## Get cross references for a propery
+## Get cross references for a property
 `​/api​/v2​/properties​/{uprn}​/crossreferences`
 
 There are no changes to this endpoint.
-
-
-
-


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/PA-401

## Describe this PR

### *What is the problem we're trying to solve*

We want to allow a user to filter addresses by a specific cross-reference.

### *What changes have we introduced*

This adds two query parameters: `cross_ref_code` and `cross_ref_value`. They cannot be supplied on their own and must either both exist or are both equal to null. We've added validation to the request to check that this is the case.

#### _Checklist_

- [X] Added end-to-end (i.e. integration) tests where necessary e.g to test the complete functionality of a newly added feature
- [X] Added tests to cover all new production code
- [X] Added comments to the README or updated relevant documentation _(add a link to documentation)_, where necessary.
- [X] Checked all code for possible refactoring
- [X] Code pipeline builds correctly

### *Follow up actions after merging PR*

- Decide if we should validate that a correct cross-reference code is given and how best to do this.
- Test on Staging
