### PR TITLE
Include parent shells in the total count returned

### DIFF
--- a/AddressesAPI.Tests/V2/Gateways/AddressGatewayTest.cs
+++ b/AddressesAPI.Tests/V2/Gateways/AddressGatewayTest.cs
@@ -481,6 +481,35 @@ namespace AddressesAPI.Tests.V2.Gateways
         }
 
         [Test]
+        public void IfSetToIncludeParentShellsWillIncludeParentShellsInTotalCount()
+        {
+            var parentShell = TestEfDataHelper.InsertAddress(DatabaseContext);
+            var addressOneToMatch = TestEfDataHelper.InsertAddress(DatabaseContext,
+                request: new NationalAddress { ParentUPRN = parentShell.UPRN }
+            );
+            var parentShellTwo = TestEfDataHelper.InsertAddress(DatabaseContext);
+            var addressTwoToMatch = TestEfDataHelper.InsertAddress(DatabaseContext,
+                request: new NationalAddress { ParentUPRN = parentShellTwo.UPRN, Postcode = addressOneToMatch.Postcode }
+            );
+
+            TestEfDataHelper.InsertAddress(DatabaseContext);
+
+            var request = new SearchParameters
+            {
+                Page = 1,
+                PageSize = 2,
+                Format = GlobalConstants.Format.Detailed,
+                Gazetteer = GlobalConstants.Gazetteer.Both,
+                Postcode = addressOneToMatch.Postcode,
+                IncludeParentShells = true
+            };
+            var (addresses, totalCount) = _classUnderTest.SearchAddresses(request);
+
+            addresses.Count.Should().Be(2);
+            totalCount.Should().Be(4);
+        }
+
+        [Test]
         public void IfSetToIncludeParentShellsIncludeParentShellsOfParentsShells()
         {
             var grandParentShell = TestEfDataHelper.InsertAddress(DatabaseContext);

--- a/AddressesAPI/V2/Gateways/AddressesGateway.cs
+++ b/AddressesAPI/V2/Gateways/AddressesGateway.cs
@@ -34,7 +34,7 @@ namespace AddressesAPI.V2.Gateways
                 baseAddresses = GetParentShells(baseQuery, baseAddresses);
             }
 
-            var totalCount = baseQuery.Count();
+            var totalCount = baseAddresses.Count();
 
             var addresses = PageAddresses(OrderAddresses(baseAddresses), request.PageSize, request.Page)
                 .Select(


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/PA-402
## Describe this PR

### *What is the problem we're trying to solve*
The total count returned when searching addresses should be a sum all addresses that match the query/

### *What changes have we introduced*

The parent shells weren't being included in the total count, this PR adds them to this count.

#### _Checklist_

- [x] Added tests to cover all new production code
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly