### PR TITLE
Replace gazetteer and out_of_borough query params with address_scope

### DIFF
--- a/AddressesAPI.Tests/V2/Controllers/SearchAddressControllerTests.cs
+++ b/AddressesAPI.Tests/V2/Controllers/SearchAddressControllerTests.cs
@@ -34,9 +34,9 @@ namespace AddressesAPI.Tests.V2.Controllers
         }
 
 
-        [TestCase("RM3 0FS", GlobalConstants.Gazetteer.Hackney)]
-        [TestCase("IG11 7QD", GlobalConstants.Gazetteer.Both)]
-        public void GivenValidSearchAddressRequest_WhenCallingGet_ThenShouldReturnAPIResponseListOfAddresses(string postcode, GlobalConstants.Gazetteer gazetteer)
+        [TestCase("RM3 0FS", GlobalConstants.AddressScope.HackneyBorough)]
+        [TestCase("IG11 7QD", GlobalConstants.AddressScope.National)]
+        public void GivenValidSearchAddressRequest_WhenCallingGet_ThenShouldReturnAPIResponseListOfAddresses(string postcode, GlobalConstants.AddressScope addressScope)
         {
             //arrange
             _mock.Setup(s => s.ExecuteAsync(It.IsAny<SearchAddressRequest>()))
@@ -48,7 +48,7 @@ namespace AddressesAPI.Tests.V2.Controllers
             var request = new SearchAddressRequest
             {
                 Postcode = postcode,
-                Gazetteer = gazetteer.ToString()
+                AddressScope = addressScope.ToString()
             };
             //act
             var response = _classUnderTest.GetAddresses(request);

--- a/AddressesAPI.Tests/V2/SearchAddressRequestTests.cs
+++ b/AddressesAPI.Tests/V2/SearchAddressRequestTests.cs
@@ -8,63 +8,18 @@ namespace AddressesAPI.Tests.V2
     [TestFixture]
     public class SearchAddressRequestTests
     {
-        private static string _bothGazetteers;
-        private static string _localGazetteer;
-
-        [SetUp]
-        public void SetUp()
-        {
-            _bothGazetteers = GlobalConstants.Gazetteer.Both.ToString();
-            _localGazetteer = GlobalConstants.Gazetteer.Hackney.ToString();
-        }
-        #region Gazetteer
         [Test]
-        public void GivenNoInputForGazetteer_WhenSearchAddressRequestObjectIsCreated_ItDefaultsToBoth()
+        public void GivenNoInputValueForAddressScope_WhenSearchAddressRequestObjectIsCreated_AddressScopeIsSetToHackneyBorough()
         {
             var classUnderTest = new SearchAddressRequest();
-            classUnderTest.Gazetteer.Should().Be(_bothGazetteers);
+            classUnderTest.AddressScope.Should().Be(GlobalConstants.AddressScope.HackneyBorough.ToString());
         }
 
         [Test]
-        public void GivenInputValueLocalForGazetteer_WhenSearchAddressRequestObjectIsCreated_ItIsSetToLocal()
-        {
-            var classUnderTest = new SearchAddressRequest { Gazetteer = _localGazetteer };
-            classUnderTest.Gazetteer.Should().Be(_localGazetteer);
-        }
-
-        [Test]
-        public void GivenInputValueBothForGazetteer_WhenSearchAddressRequestObjectIsCreated_ItIsSetToBoth()
-        {
-            var classUnderTest = new SearchAddressRequest { Gazetteer = _bothGazetteers };
-            classUnderTest.Gazetteer.Should().Be(_bothGazetteers);
-        }
-        #endregion
-
-        #region OutOfBoroughAddress
-        [Test]
-        public void GivenNoInputValueForOutOfBoroughAddressParameter_WhenSearchAddressRequestObjectIsCreated_OutOfBoroughAddressIsSetToTrue()
+        public void GivenNoInputValueForAddressStatus_WhenSearchAddressRequestObjectIsCreated_AddressStatusIsSetToApproved()
         {
             var classUnderTest = new SearchAddressRequest();
-            classUnderTest.OutOfBoroughAddress.Should().BeTrue();
+            classUnderTest.AddressStatus.Should().Be("approved");
         }
-
-        [TestCase("Both", false)]
-        [TestCase("Both", true)]
-        [TestCase("Local", false)]
-        [TestCase("Local", true)]
-        public void GivenAHackneyGazetteerOutOfBoroughAddressInputValueAndAnyGazetteerValue_WhenSearchAddressRequestObjectIsCreated_HackneyGazetteerOutOfBoroughAddressIsSetToWhateverItsInputWas(string gazetteer, bool hackneyGazetteerOutOfBoroughAddress)
-        {
-            var classUnderTest = new SearchAddressRequest { Gazetteer = gazetteer, OutOfBoroughAddress = hackneyGazetteerOutOfBoroughAddress };
-            classUnderTest.OutOfBoroughAddress.Should().Be(hackneyGazetteerOutOfBoroughAddress);
-        }
-
-        [TestCase(true)]
-        [TestCase(false)]
-        public void GivenNoInputForGazetteerAndInputValueForHackneyGazetteerOutOfBoroughAddress_WhenSearchAddressRequestObjectIsCreated_HackneyGazetteerOutOfBoroughAddressIsSetToWhateverItsInputWas(bool hackneyGazetteerOutOfBoroughAddress)
-        {
-            var classUnderTest = new SearchAddressRequest { OutOfBoroughAddress = hackneyGazetteerOutOfBoroughAddress };
-            classUnderTest.OutOfBoroughAddress.Should().Be(hackneyGazetteerOutOfBoroughAddress);
-        }
-        #endregion
     }
 }

--- a/AddressesAPI.Tests/V2/UseCase/SearchAddressValidatorTests.cs
+++ b/AddressesAPI.Tests/V2/UseCase/SearchAddressValidatorTests.cs
@@ -12,11 +12,13 @@ namespace AddressesAPI.Tests.V2.UseCase
     {
         private SearchAddressValidator _classUnderTest;
         private string _localGazetteer;
+        private string _nationalGazetteer;
 
         [SetUp]
         public void SetUp()
         {
-            _localGazetteer = GlobalConstants.Gazetteer.Hackney.ToString();
+            _localGazetteer = GlobalConstants.AddressScope.HackneyGazetteer.ToString();
+            _nationalGazetteer = GlobalConstants.AddressScope.National.ToString();
             _classUnderTest = new SearchAddressValidator();
         }
 
@@ -261,101 +263,106 @@ namespace AddressesAPI.Tests.V2.UseCase
         #region Request object validation
 
         [TestCase(12345)]
-        public void GivenARequestWithOnlyUPRN_IfGazetteerIsLocal_WhenCallingValidation_ItReturnsNoError(int uprn)
+        public void GivenARequestWithOnlyUPRN_IfAddressScopeIsHackneyGazetteer_WhenCallingValidation_ItReturnsNoError(int uprn)
         {
-            var request = new SearchAddressRequest() { UPRN = uprn, Gazetteer = _localGazetteer };
+            var request = new SearchAddressRequest() { UPRN = uprn, AddressScope = _localGazetteer };
             _classUnderTest.TestValidate(request).ShouldNotHaveError();
         }
 
         [TestCase(12345)]
-        public void GivenARequestWithOnlyUPRN_IfGazetteerIsBoth_WhenCallingValidation_ItReturnsNoError(int uprn)
+        public void GivenARequestWithOnlyUPRN_IfAddressScopeIsHackneyNational_WhenCallingValidation_ItReturnsNoError(int uprn)
         {
-            var request = new SearchAddressRequest() { UPRN = uprn };
+            var request = new SearchAddressRequest() { UPRN = uprn, AddressScope = _nationalGazetteer };
             _classUnderTest.TestValidate(request).ShouldNotHaveError();
         }
 
         [TestCase(12345)]
-        public void GivenARequestWithOnlyUSRN_IfGazetteerIsLocal_WhenCallingValidation_ItReturnsNoError(int usrn)
+        public void GivenARequestWithOnlyUSRN_IfAddressScopeIsHackneyGazetteer_WhenCallingValidation_ItReturnsNoError(int usrn)
         {
-            var request = new SearchAddressRequest() { USRN = usrn, Gazetteer = _localGazetteer };
+            var request = new SearchAddressRequest() { USRN = usrn, AddressScope = _localGazetteer };
             _classUnderTest.TestValidate(request).ShouldNotHaveError();
         }
 
         [TestCase(12345)]
-        public void GivenARequestWithOnlyUSRN_IfGazetteerIsBoth_WhenCallingValidation_ItReturnsNoError(int usrn)
+        public void GivenARequestWithOnlyUSRN_IfAddressScopeIsNational_WhenCallingValidation_ItReturnsNoError(int usrn)
         {
-            var request = new SearchAddressRequest() { USRN = usrn };
+            var request = new SearchAddressRequest() { USRN = usrn, AddressScope = _nationalGazetteer };
             _classUnderTest.TestValidate(request).ShouldNotHaveError();
         }
 
         [TestCase("SW1A 1AA")]
-        public void GivenARequestWithOnlyAPostCode_IfGazetteerIsLocal_WhenCallingValidation_ItReturnsNoError(string postcode)
+        public void GivenARequestWithOnlyAPostCode_IfAddressScopeIsHackneyGazetteer_WhenCallingValidation_ItReturnsNoError(string postcode)
         {
-            var request = new SearchAddressRequest() { Postcode = postcode, Gazetteer = _localGazetteer };
+            var request = new SearchAddressRequest() { Postcode = postcode, AddressScope = _localGazetteer };
             _classUnderTest.TestValidate(request).ShouldNotHaveError();
         }
 
         [TestCase("SW1A 1AA")]
-        public void GivenARequestWithOnlyAPostCode_IfGazetteerIsBoth_WhenCallingValidation_ItReturnsNoError(string postcode)
+        public void GivenARequestWithOnlyAPostCode_IfAddressScopeIsNational_WhenCallingValidation_ItReturnsNoError(string postcode)
         {
-            var request = new SearchAddressRequest() { Postcode = postcode };
+            var request = new SearchAddressRequest() { Postcode = postcode, AddressScope = _nationalGazetteer };
             _classUnderTest.TestValidate(request).ShouldNotHaveError();
         }
 
         [TestCase("Sesame street")]
-        public void GivenARequestWithOnlyAStreet_IfGazetteerIsLocal_WhenCallingValidation_ItReturnsNoError(string street)
+        public void GivenARequestWithOnlyAStreet_IfAddressScopeIsHackneyGazetteer_WhenCallingValidation_ItReturnsNoError(string street)
         {
-            var request = new SearchAddressRequest() { Street = street, Gazetteer = _localGazetteer };
+            var request = new SearchAddressRequest() { Street = street, AddressScope = _localGazetteer };
             _classUnderTest.TestValidate(request).ShouldNotHaveError();
         }
 
         [TestCase("Sesame street")]
-        public void GivenARequestWithOnlyAStreet_IfGazetteerIsBoth_WhenCallingValidation_ItReturnsAnError(string street)
+        public void GivenARequestWithOnlyAStreet_IfAddressScopeIsNational_WhenCallingValidation_ItReturnsAnError(string street)
         {
-            var request = new SearchAddressRequest() { Street = street };
-            _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage("You must provide at least one of (uprn, usrn, postcode), when gazetteer is 'both'.");
+            var request = new SearchAddressRequest() { Street = street, AddressScope = _nationalGazetteer };
+            _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage(
+                "You must provide at least one of (uprn, usrn, postcode), when address_scope is 'national'.");
         }
 
         [TestCase("someValue")]
-        public void GivenARequestWithOnlyUsagePrimary_IfGazetteerIsLocal_WhenCallingValidation_ItReturnsNoError(string usagePrimary)
+        public void GivenARequestWithOnlyUsagePrimary_IfAddressScopeIsHackneyGazetteer_WhenCallingValidation_ItReturnsNoError(string usagePrimary)
         {
-            var request = new SearchAddressRequest() { UsagePrimary = usagePrimary, Gazetteer = _localGazetteer };
+            var request = new SearchAddressRequest() { UsagePrimary = usagePrimary, AddressScope = _localGazetteer };
             _classUnderTest.TestValidate(request).ShouldNotHaveError();
         }
 
         [TestCase("someValue")]
-        public void GivenARequestWithOnlyUsagePrimary_IfGazetteerIsBoth_WhenCallingValidation_ItReturnsAnError(string usagePrimary)
+        public void GivenARequestWithOnlyUsagePrimary_IfAddressScopeIsNational_WhenCallingValidation_ItReturnsAnError(string usagePrimary)
         {
-            var request = new SearchAddressRequest() { UsagePrimary = usagePrimary };
-            _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage("You must provide at least one of (uprn, usrn, postcode), when gazetteer is 'both'.");
+            var request = new SearchAddressRequest() { UsagePrimary = usagePrimary, AddressScope = _nationalGazetteer };
+            _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage(
+                "You must provide at least one of (uprn, usrn, postcode), when address_scope is 'national'.");
         }
 
         [TestCase("otherValue")]
-        public void GivenARequestWithOnlyUsageCode_IfGazetteerIsLocal_WhenCallingValidation_ItReturnsNoError(string usageCode)
+        public void GivenARequestWithOnlyUsageCode_IfAddressScopeIsHackneyGazetteer_WhenCallingValidation_ItReturnsNoError(string usageCode)
         {
-            var request = new SearchAddressRequest() { UsageCode = usageCode, Gazetteer = _localGazetteer };
+            var request = new SearchAddressRequest() { UsageCode = usageCode, AddressScope = _localGazetteer };
             _classUnderTest.TestValidate(request).ShouldNotHaveError();
         }
 
         [TestCase("otherValue")]
-        public void GivenARequestWithOnlyUsageCode_IfGazetteerIsBoth_WhenCallingValidation_ItReturnsAnError(string usageCode)
+        public void GivenARequestWithOnlyUsageCode_IfAddressScopeIsNational_WhenCallingValidation_ItReturnsAnError(string usageCode)
         {
-            var request = new SearchAddressRequest() { UsageCode = usageCode };
-            _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage("You must provide at least one of (uprn, usrn, postcode), when gazetteer is 'both'.");
+            var request = new SearchAddressRequest() { UsageCode = usageCode, AddressScope = _nationalGazetteer };
+            _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage(
+                "You must provide at least one of (uprn, usrn, postcode), when address_scope is 'national'.");
         }
 
         [TestCase("12345")]
-        public void GivenARequestWithNoMandatoryFields_IfGazetteerIsLocal_WhenCallingValidation_ItReturnsAnError(string buildingNumber)
+        public void GivenARequestWithNoMandatoryFields_IfAddressScopeIsHackneyGazetteer_WhenCallingValidation_ItReturnsAnError(string buildingNumber)
         {
-            var request = new SearchAddressRequest() { BuildingNumber = buildingNumber, Gazetteer = _localGazetteer };
-            _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage("You must provide at least one of (uprn, usrn, postcode, street, usagePrimary, usageCode), when gazeteer is 'local'.");
+            var request = new SearchAddressRequest() { BuildingNumber = buildingNumber, AddressScope = _localGazetteer };
+            _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage(
+                "You must provide at least one of (uprn, usrn, postcode, street, usagePrimary, usageCode), when address_scope is 'hackney borough' or 'hackney gazetteer'.");
         }
 
         [TestCase("12345")]
-        public void GivenARequestWithNoMandatoryFields_IfGazetteerIsBoth_WhenCallingValidation_ItReturnsAnError(string buildingNumber)
+        public void GivenARequestWithNoMandatoryFields_IfAddressScopeIsNational_WhenCallingValidation_ItReturnsAnError(string buildingNumber)
         {
-            var request = new SearchAddressRequest() { BuildingNumber = buildingNumber };
-            _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage("You must provide at least one of (uprn, usrn, postcode), when gazetteer is 'both'.");
+            var request = new SearchAddressRequest() { BuildingNumber = buildingNumber, AddressScope = _nationalGazetteer };
+            _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage(
+                "You must provide at least one of (uprn, usrn, postcode), when address_scope is 'national'.");
         }
 
         [TestCase("TESTCD", "E5 9TT")]
@@ -399,21 +406,27 @@ namespace AddressesAPI.Tests.V2.UseCase
         [TestCase("finsburypark")]
         [TestCase("haringay")]
         [TestCase("dalston")]
-        [TestCase("National")]
-        public void GivenAnIncorrectGazetteer_WhenValidating_ItReturnsAnError(string gazetteer)
+        [TestCase("Both")]
+        [TestCase("Hackney")]
+        public void GivenAnIncorrectAddressScope_WhenValidating_ItReturnsAnError(string addressScope)
         {
-            var request = new SearchAddressRequest { Gazetteer = gazetteer };
-            _classUnderTest.ShouldHaveValidationErrorFor(x => x.Gazetteer, request)
-                .WithErrorMessage("Value for the parameter is not valid. It should be either Hackney or Both.");
+            var request = new SearchAddressRequest { AddressScope = addressScope };
+            _classUnderTest.ShouldHaveValidationErrorFor(x => x.AddressScope, request)
+                .WithErrorMessage("Value for the parameter is not valid. It should be either Hackney Borough, Hackney Gazetteer or National.");
         }
 
-        [TestCase("Hackney")]
-        [TestCase("Local")] // To be depreciated
-        [TestCase("Both")]
-        public void GivenACorrectGazetteer_WhenValidating_ItReturnsNoErrors(string gazetteer)
+        [TestCase("hackney borough")]
+        [TestCase("hackneyborough")]
+        [TestCase("Hackney Borough")]
+        [TestCase("hackney gazetteer")]
+        [TestCase("hackneygazetteer")]
+        [TestCase("Hackney Gazetteer")]
+        [TestCase("national")]
+        [TestCase("National")]
+        public void GivenACorrectAddressScope_WhenValidating_ItReturnsNoErrors(string addressScope)
         {
-            var request = new SearchAddressRequest { Gazetteer = gazetteer };
-            _classUnderTest.ShouldNotHaveValidationErrorFor(x => x.Gazetteer, request);
+            var request = new SearchAddressRequest { AddressScope = addressScope };
+            _classUnderTest.ShouldNotHaveValidationErrorFor(x => x.AddressScope, request);
         }
 
         #endregion

--- a/AddressesAPI/V2/Boundary/Requests/SearchAddressRequest.cs
+++ b/AddressesAPI/V2/Boundary/Requests/SearchAddressRequest.cs
@@ -32,9 +32,10 @@ namespace AddressesAPI.V2.Boundary.Requests
         public string Street { get; set; }
 
         /// <summary>
-        /// LOCAL/NATIONAL/BOTH (Defaults to LOCAL)
+        /// Hackney Borough/Hackney Gazetteer/National (Defaults to Hackney Borough)
         /// </summary>
-        public string Gazetteer { get; set; } = GlobalConstants.Gazetteer.Both.ToString();
+        [FromQuery(Name = "address_scope")]
+        public string AddressScope { get; set; } = GlobalConstants.AddressScope.HackneyBorough.ToString();
 
         /// <summary>
         /// Filter by UPRN (unique property reference number - unique identifier of the BLPU (Basic Land and Property Unit); a UPRN can have more than one LPI/address. )
@@ -82,17 +83,6 @@ namespace AddressesAPI.V2.Boundary.Requests
         /// </summary>
         [FromQuery(Name = "address_status")]
         public string AddressStatus { get; set; }
-
-        /// <summary>
-        ///  	whether or not out of borough addresses
-        ///that are present in the local gazetteer
-        ///for services reasons should be returned.
-        ///If yes, the local gazetteer version takes
-        ///precedence over the national gazetteer
-        ///version.
-        /// </summary>
-        [FromQuery(Name = "out_of_borough")]
-        public bool OutOfBoroughAddress { get; set; } = true;
 
         /// <summary>
         /// Whether or not to include parent shells of addresses which match

--- a/AddressesAPI/V2/GlobalConstants.cs
+++ b/AddressesAPI/V2/GlobalConstants.cs
@@ -7,6 +7,13 @@ namespace AddressesAPI.V2
 
         public const int Offset = 0;
 
+        public enum AddressScope
+        {
+            HackneyBorough,
+            HackneyGazetteer,
+            National
+        }
+
         public enum Format
         {
             Simple,

--- a/AddressesAPI/V2/UseCase/SearchAddressUseCase.cs
+++ b/AddressesAPI/V2/UseCase/SearchAddressUseCase.cs
@@ -45,13 +45,14 @@ namespace AddressesAPI.V2.UseCase
 
         private static SearchParameters MapRequestToSearchParameters(SearchAddressRequest request)
         {
-            var gazetteer = request.Gazetteer.ToLower() == "local"
-                ? GlobalConstants.Gazetteer.Hackney
-                : Enum.Parse<GlobalConstants.Gazetteer>(request.Gazetteer, true);
+            var addressScope = Enum.Parse<GlobalConstants.AddressScope>(request.AddressScope.Replace(" ", ""), true);
+
             return new SearchParameters
             {
                 Format = Enum.Parse<GlobalConstants.Format>(request.Format, true),
-                Gazetteer = gazetteer,
+                Gazetteer = addressScope != GlobalConstants.AddressScope.National
+                    ? GlobalConstants.Gazetteer.Hackney
+                    : GlobalConstants.Gazetteer.Both,
                 Page = request.Page == 0 ? 1 : request.Page,
                 Postcode = request.Postcode,
                 Street = request.Street,
@@ -62,7 +63,7 @@ namespace AddressesAPI.V2.UseCase
                 PageSize = request.PageSize,
                 UsageCode = request.UsageCode,
                 UsagePrimary = request.UsagePrimary,
-                OutOfBoroughAddress = request.OutOfBoroughAddress,
+                OutOfBoroughAddress = addressScope != GlobalConstants.AddressScope.HackneyBorough,
                 IncludeParentShells = request.IncludeParentShells,
                 CrossRefCode = request.CrossRefCode,
                 CrossRefValue = request.CrossRefValue

--- a/AddressesAPI/V2/UseCase/SearchAddressValidator.cs
+++ b/AddressesAPI/V2/UseCase/SearchAddressValidator.cs
@@ -18,9 +18,9 @@ namespace AddressesAPI.V2.UseCase
                 .Must(CanBeAnyCombinationOfAllowedAddressStatuses)
                 .WithMessage("Value for the parameter is not valid.");
 
-            RuleFor(r => r.Gazetteer)
-                .Must(gazetteer => gazetteer.ToLower() == "local" || Enum.TryParse<GlobalConstants.Gazetteer>(gazetteer, true, out _))
-                .WithMessage("Value for the parameter is not valid. It should be either Hackney or Both.");
+            RuleFor(r => r.AddressScope)
+                .Must(addressScope => Enum.TryParse<GlobalConstants.AddressScope>(addressScope?.Replace(" ", ""), true, out _))
+                .WithMessage("Value for the parameter is not valid. It should be either Hackney Borough, Hackney Gazetteer or National.");
 
             RuleFor(r => r.Format)
                 .Must(format => Enum.TryParse<GlobalConstants.Format>(format, true, out _))
@@ -34,12 +34,12 @@ namespace AddressesAPI.V2.UseCase
                 .WithMessage("Must provide at least the first part of the postcode.");
 
             RuleFor(r => r)
-                .Must(CheckForAtLeastOneMandatoryFilterPropertyWithGazetteerLocal)
-                .WithMessage("You must provide at least one of (uprn, usrn, postcode, street, usagePrimary, usageCode), when gazeteer is 'local'.");
+                .Must(CheckForAtLeastOneMandatoryFilterPropertyWithHackneyGazetteer)
+                .WithMessage("You must provide at least one of (uprn, usrn, postcode, street, usagePrimary, usageCode), when address_scope is 'hackney borough' or 'hackney gazetteer'.");
 
             RuleFor(r => r)
-                .Must(CheckForAtLeastOneMandatoryFilterPropertyWithGazetteerBoth)
-                .WithMessage("You must provide at least one of (uprn, usrn, postcode), when gazetteer is 'both'.");
+                .Must(CheckForAtLeastOneMandatoryFilterPropertyWithNationalGazetteer)
+                .WithMessage("You must provide at least one of (uprn, usrn, postcode), when address_scope is 'national'.");
 
             RuleFor(r => r)
                 .Must(CheckCrossReferenceCodeWhenGivenHasAValue)
@@ -66,9 +66,9 @@ namespace AddressesAPI.V2.UseCase
             return !invalidParameters.Any();
         }
 
-        private static bool CheckForAtLeastOneMandatoryFilterPropertyWithGazetteerLocal(SearchAddressRequest request)
+        private static bool CheckForAtLeastOneMandatoryFilterPropertyWithHackneyGazetteer(SearchAddressRequest request)
         {
-            return request.Gazetteer == GlobalConstants.Gazetteer.Both.ToString()
+            return request.AddressScope.Equals(GlobalConstants.AddressScope.National.ToString(), StringComparison.InvariantCultureIgnoreCase)
                    || request.UPRN != null
                    || request.USRN != null
                    || request.Postcode != null
@@ -77,9 +77,9 @@ namespace AddressesAPI.V2.UseCase
                    || request.UsageCode != null;
         }
 
-        private static bool CheckForAtLeastOneMandatoryFilterPropertyWithGazetteerBoth(SearchAddressRequest request)
+        private static bool CheckForAtLeastOneMandatoryFilterPropertyWithNationalGazetteer(SearchAddressRequest request)
         {
-            return request.Gazetteer != GlobalConstants.Gazetteer.Both.ToString()
+            return !request.AddressScope.Equals(GlobalConstants.AddressScope.National.ToString(), StringComparison.InvariantCultureIgnoreCase)
                    || request.UPRN != null
                    || request.USRN != null
                    || request.Postcode != null;


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

Simplify the combination of the `gazetteer` and `out_of_borough` query parameters. Currently, the logic for these two query parameters is somewhat intertwined, to hopefully simplify this we have removed them both and introduced the `address_scope` query parameter.
`address_scope` can take values: `hackney borough`, `hackney gazetteer` and `national`.

 It's relationship to the old parameters is:
`gazeeter=hackney&out_of_borough=false` or `gazeeter=both&out_of_borough=false` => `address_scope=hackney borough`
`gazeeter=hackney&out_of_borough=true` => `address_scope=hackney gazetteer`
`gazeeter=both&out_of_borough=true` => `address_scope=national`

This is only changing the query parameters and does not affect the responses or whats stored in the database. 

The [swagger](https://app.swaggerhub.com/apis-docs/Hackney/addresses-api/1.0.0#/default/get_api_v1_addresses) has been updated to reflect this change.

### *What changes have we introduced*

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly