### PR TITLE
Declare Target Elasticsearch Endpoint as a separate resource

### DIFF
--- a/terraform/staging/task_settings.json
+++ b/terraform/staging/task_settings.json
@@ -8,7 +8,7 @@
       "LobMaxSize": 32,
       "InlineLobMaxSize": 0,
       "LoadMaxFileSize": 0,
-      "ParallelLoadThreads": 1,
+      "ParallelLoadThreads": 2,
       "ParallelLoadBufferSize": 50,
       "BatchApplyEnabled": false,
       "TaskRecoveryTableEnabled": false,


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/PA-408

## Describe this PR

### *What is the problem we're trying to solve*

The previous setup of DMS for Elasticsearch errored in Staging (PR #51). 
This PR introduces fixes from troubleshooting the issue.

### *What changes have we introduced*

This declares:
- A resource for the target endpoint
- A module for the source endpoint
- A module for the DMS replication task
- Sets the parallel load threads to 2 (Errors if not between 2 and 200)
- Sets migration type to full load (Cannot target view as source table otherwise)

#### _Checklist_
- [X] Code pipeline builds correctly

### *Follow up actions after merging PR*

- Check DMS task is created in Staging and works
- Check DMS task is created in Production and works