### PR TITLE
Remove postcode uprn obligation for cross reference query

### DIFF
--- a/AddressesAPI.Tests/V2/E2ETests/SearchAddressIntegrationTests.cs
+++ b/AddressesAPI.Tests/V2/E2ETests/SearchAddressIntegrationTests.cs
@@ -226,7 +226,7 @@ namespace AddressesAPI.Tests.V2.E2ETests
         }
 
         [Test]
-        public async Task SearchAddressReturnsAnAddressMatchingASpecificCrossReference()
+        public async Task SearchAddressReturnsAddressesInHackneyBoroughForAGivenCrossReference()
         {
             var uprnOne = _faker.Random.Int();
             var uprnTwo = _faker.Random.Int();
@@ -234,16 +234,20 @@ namespace AddressesAPI.Tests.V2.E2ETests
             var crossReferenceOne = new CrossReference { Code = "000ABC", Value = "100000" };
             var crossReferenceTwo = new CrossReference { Code = "123XYZ", Value = "100000" };
 
-            var record = TestEfDataHelper.InsertAddress(DatabaseContext, request: new NationalAddress { UPRN = uprnOne, Postcode = "N1 7UK" });
+            var hackneyBoroughOne = new NationalAddress { UPRN = uprnOne, Gazetteer = "Hackney", NeverExport = false };
+            var hackneyBoroughTwo = new NationalAddress { UPRN = uprnTwo, Gazetteer = "Hackney", NeverExport = false };
+
+            var record = TestEfDataHelper.InsertAddress(DatabaseContext,
+                request: hackneyBoroughOne);
+
             TestEfDataHelper.InsertCrossReference(DatabaseContext, uprnOne, crossReferenceOne);
 
-
-            TestEfDataHelper.InsertAddress(DatabaseContext, request: new NationalAddress { UPRN = uprnTwo, Postcode = "N1 7UK" });
+            TestEfDataHelper.InsertAddress(DatabaseContext, request: hackneyBoroughTwo);
             TestEfDataHelper.InsertCrossReference(DatabaseContext, uprnTwo, crossReferenceTwo);
 
             AddSomeRandomAddressToTheDatabase();
 
-            var queryString = $"cross_ref_code={crossReferenceOne.Code}&cross_ref_value={crossReferenceOne.Value}&postcode=N1&format=Detailed&address_scope=national";
+            var queryString = $"cross_ref_code={crossReferenceOne.Code}&cross_ref_value={crossReferenceOne.Value}&format=Detailed";
 
             var response = await CallEndpointWithQueryParameters(queryString).ConfigureAwait(true);
             response.StatusCode.Should().Be(200);

--- a/AddressesAPI/V2/UseCase/SearchAddressValidator.cs
+++ b/AddressesAPI/V2/UseCase/SearchAddressValidator.cs
@@ -68,13 +68,20 @@ namespace AddressesAPI.V2.UseCase
 
         private static bool CheckForAtLeastOneMandatoryFilterPropertyWithHackneyGazetteer(SearchAddressRequest request)
         {
+            var crossReferenceParametersGiven = request.CrossRefCode != null && request.CrossRefValue != null;
+
+            if (crossReferenceParametersGiven)
+            {
+                return true;
+            }
+
             return request.AddressScope.Equals(GlobalConstants.AddressScope.National.ToString(), StringComparison.InvariantCultureIgnoreCase)
-                   || request.UPRN != null
-                   || request.USRN != null
-                   || request.Postcode != null
-                   || request.Street != null
-                   || request.UsagePrimary != null
-                   || request.UsageCode != null;
+                                              || request.UPRN != null
+                                              || request.USRN != null
+                                              || request.Postcode != null
+                                              || request.Street != null
+                                              || request.UsagePrimary != null
+                                              || request.UsageCode != null;
         }
 
         private static bool CheckForAtLeastOneMandatoryFilterPropertyWithNationalGazetteer(SearchAddressRequest request)

--- a/V2Changelog.md
+++ b/V2Changelog.md
@@ -84,6 +84,9 @@ Going forward they will look like:
 An example of a parent shell would be a house converted into flats, each flat in the house would have it's own address (e.g. 1st Floor Flat, 5 Hackney Avenue) and then it's parent shell would be the address of the house (e.g. 5 Hackney Avenue).
 7. Two new optional query parameters have been added to allow a user to filter addresses by a specific cross reference. These are `cross_ref_code` and `cross_ref_value`. If filtering by a cross reference, both must be supplied i.e You cannot supply just a `cross_ref_code`. If only one has been supplied, the endpoint will return 400 (Bad Request) error. When both are given, the endpoint will return all addresses that match the cross reference given.
 
+## Changes to the search addresses request validation
+1. When filtering by cross reference (i.e. when a specific `cross_ref_code` & `cross_ref_value` is given in the request), there is no obligation for the user to also pass in a postcode, UPRN, USRN, street or usageCode as part of the request. The `addressScope` in the request is also forced to be set to `HackneyBorough` (i.e does not include out of borough addresses). This is because when querying by cross reference, we only want to filter through addresses in the Hackney Borough.
+
 # Properties
 ## Get cross references for a property
 `​/api​/v2​/properties​/{uprn}​/crossreferences`


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/PA-401

## Describe this PR

### *What is the problem we're trying to solve*

When querying by a cross-reference, the user doesn't need to pass in a postcode, UPRN, USRN, usage code or usage primary.

The request should this be valid if a cross-reference has been given but not postcode, UPRN, USRN, usage code or usage primary.

### *What changes have we introduced*

- Edit the validation to ignore the need for at least a postcode, UPRN, USRN, usage code or usage primary if both a cross-reference code and a value has been given.

#### _Checklist_

- [X] Added end-to-end (i.e. integration) tests where necessary e.g to test the complete functionality of a newly added feature
- [X] Added tests to cover all new production code
- [X] Added comments to the README or updated relevant documentation _(add a link to documentation)_, where necessary.
- [X] Checked all code for possible refactoring
- [X] Code pipeline builds correctly

### *Follow up actions after merging PR*

- Test in Staging