### PR TITLE
DMS from hackney/ national address tables instead of combined view

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,18 +229,18 @@ workflows:
             branches:
               only: development
   check-and-deploy-staging-and-production:
-      jobs:
+    jobs:
       - build-and-test:
-          filters:
-            branches:
-              only: master
+        filters:
+          branches:
+            only: master
       - assume-role-staging:
           context: api-assume-role-staging-context
           requires:
-              - build-and-test
+            - build-and-test
           filters:
-             branches:
-               only: master
+            branches:
+              only: master
       - terraform-init-and-apply-to-staging:
           requires:
             - assume-role-staging

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -143,7 +143,7 @@ module "address-es-dms" {
   source                       = "github.com/LBHackney-IT/aws-dms-terraform.git//dms_replication_task"
   environment_name             = "staging"
   project_name                 = "addresses-api"
-  migration_type               = "full-load"
+  migration_type               = "full-load-and-cdc"
   replication_instance_arn     = "arn:aws:dms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rep:DNTOW6TGQEGCAOWQMZYHQRTWAA"
   replication_task_indentifier = "addresses-api-es-dms-task"
   task_settings                = file("${path.module}/task_settings.json")

--- a/terraform/staging/selection_rules.json
+++ b/terraform/staging/selection_rules.json
@@ -6,8 +6,7 @@
       "rule-name": "1",
       "object-locator": {
         "schema-name": "%",
-        "table-name": "combined_address",
-        "table-type": "view"
+        "table-name": "hackney_address"
       },
       "rule-action": "include"
     },
@@ -17,7 +16,7 @@
       "rule-name": "2",
       "object-locator": {
         "schema-name": "%",
-        "table-name": "hackney_xref"
+        "table-name": "national_address"
       },
       "rule-action": "include"
     },
@@ -29,8 +28,212 @@
       "rule-target": "column",
       "object-locator": {
         "schema-name": "%",
-        "table-name": "combined_address",
+        "table-name": "hackney_address",
         "column-name": "postcode_nospace"
+      }
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "4",
+      "rule-name": "4",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "national_address",
+        "column-name": "postcode_nospace"
+      }
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "5",
+      "rule-name": "5",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "hackney_address",
+        "column-name": "organisation"
+      }
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "6",
+      "rule-name": "6",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "national_address",
+        "column-name": "organisation"
+      }
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "7",
+      "rule-name": "7",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "hackney_address",
+        "column-name": "latitude"
+      }
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "8",
+      "rule-name": "8",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "national_address",
+        "column-name": "latitude"
+      }
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "9",
+      "rule-name": "9",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "hackney_address",
+        "column-name": "longitude"
+      }
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "10",
+      "rule-name": "10",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "national_address",
+        "column-name": "longitude"
+      }
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "11",
+      "rule-name": "11",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "hackney_address",
+        "column-name": "planning_use_class"
+      }
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "12",
+      "rule-name": "12",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "national_address",
+        "column-name": "planning_use_class"
+      }
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "13",
+      "rule-name": "13",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "hackney_address",
+        "column-name": "ward"
+      }
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "14",
+      "rule-name": "14",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "national_address",
+        "column-name": "ward"
+      }
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "15",
+      "rule-name": "15",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "hackney_address",
+        "column-name": "locality"
+      }
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "16",
+      "rule-name": "16",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "national_address",
+        "column-name": "locality"
+      }
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "17",
+      "rule-name": "17",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "hackney_address",
+        "column-name": "northing"
+      }
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "18",
+      "rule-name": "18",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "national_address",
+        "column-name": "northing"
+      }
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "19",
+      "rule-name": "19",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "hackney_address",
+        "column-name": "easting"
+      }
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "20",
+      "rule-name": "20",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "national_address",
+        "column-name": "easting"
       }
     }
   ]


### PR DESCRIPTION

## Link to JIRA ticket

https://hackney.atlassian.net/browse/PA-408
## Describe this PR

### *What is the problem we're trying to solve*

Views can't be used as a source for DMS so we are setting up DMS to pull from the two tables instead of the combined view.
This PR also removes columns which aren't used for querying and changes the migration type to `full-load-and-cdc`.

#### _Checklist_

- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Apply the same changes to production.
