### PR TITLE
increase postgres storage for staging

### DIFF
--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -70,7 +70,7 @@ module "postgres_db_staging" {
   db_engine            = "postgres"
   db_engine_version    = "11.8"
   db_instance_class    = "db.t2.micro"
-  db_allocated_storage = 40
+  db_allocated_storage = 60
   maintenance_window   = "sun:10:00-sun:10:30"
   db_username          = data.aws_ssm_parameter.addresses_postgres_username.value
   db_password          = data.aws_ssm_parameter.addresses_postgres_db_password.value


### PR DESCRIPTION
The logs needed for DMS ongoing replication is pushing the database memory to nearly full up, so increasing the size to allow for this.

I will also setup some alerting for when the rds is nearly full in staging and production. 