### PR TITLE
Refactor parent shell queries

### DIFF
--- a/AddressesAPI/V2/Gateways/AddressesGateway.cs
+++ b/AddressesAPI/V2/Gateways/AddressesGateway.cs
@@ -27,7 +27,7 @@ namespace AddressesAPI.V2.Gateways
         public List<Domain.Address> GetAddresses(List<string> addressKeys, GlobalConstants.Format format)
         {
             var addresses = _addressesContext.Addresses
-                .Where(a => addressKeys.Contains(a.AddressKey));
+                .Where(a => addressKeys.Contains(a.AddressKey)).ToList();
 
             return addressKeys
                 .Select(a => addresses.FirstOrDefault(ad => ad.AddressKey == a))

--- a/serverless.yml
+++ b/serverless.yml
@@ -5,15 +5,6 @@ provider:
   vpc: ${self:custom.vpc.${opt:stage}}
   stage: ${opt:stage}
   region: eu-west-2
-  apiKeys:
-    - secureAccess:
-      - api-key-${self:service}-${self:provider.stage}
-  usagePlan:
-    - secureAccess:
-        throttle:
-          burstLimit: 200
-          rateLimit: 100
-
 package:
   individually: true
 

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -70,7 +70,7 @@ module "postgres_db_staging" {
   db_engine            = "postgres"
   db_engine_version    = "11.8"
   db_instance_class    = "db.t2.micro"
-  db_allocated_storage = 40
+  db_allocated_storage = 60
   maintenance_window   = "sun:10:00-sun:10:30"
   db_username          = data.aws_ssm_parameter.addresses_postgres_username.value
   db_password          = data.aws_ssm_parameter.addresses_postgres_db_password.value


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/PA-411
## Describe this PR

### *What is the problem we're trying to solve*

When executing queries with the `include_parent_shells=true` flag and a broad postcode (e.g. `E8`) the lambda was taking around 7-10 seconds to execute which is too slow. 
 
### *What changes have we introduced*

To try and speed this up a bit, I've refactored the logic where we work out the list of parent shells to include. 
previously the API would
1, Get a list of all addresses which match the main query.
2, Go through all of them in memory and find those that have parent UPRNS.
3, Then repeat the process for those parents to see if they have parents
Whilst do this it was compiling a list of address keys, which it would then use to compute the final query where it would apply sorting and paging.

Now it 
1, Gets a list of all addresses which match the main query and have a parent uprn. Saves the parent uprns retrieved to a list.
2, In turn gets a list of any of those parents who also have a parent, and saves their uprns to the list
3, etc..
It will then concatenate a query to get all addresses with the gathered uprns with the base query, using an `OR` operator then apply sorting an paging

It now runs in ~4-5 seconds

- I also removed the API keys and usage plans from serverless as they are no longer being used.

### *Follow up actions after merging PR*

Still a lot more room for improvement so will continue to look for more optimisations
