### PR TITLE
Address lines full text search

### DIFF
--- a/AddressesAPI.Tests/V2/Helper/TestDataHelper.cs
+++ b/AddressesAPI.Tests/V2/Helper/TestDataHelper.cs
@@ -83,6 +83,7 @@ namespace AddressesAPI.Tests.V2.Helper
             var fixture = new Fixture();
             var randomAddressRecord = fixture.Build<QueryableAddress>()
                 .With(a => a.AddressStatus, request?.AddressStatus ?? "Approved")
+                .Without(a => a.FullAddress)
                 .Create();
             if (key != null) randomAddressRecord.AddressKey = key;
             if (request?.Postcode != null) randomAddressRecord.Postcode = ReplaceEmptyStringWithNull(request.Postcode);

--- a/AddressesAPI.Tests/V2/UseCase/SearchAddressUseCaseTest.cs
+++ b/AddressesAPI.Tests/V2/UseCase/SearchAddressUseCaseTest.cs
@@ -46,6 +46,7 @@ namespace AddressesAPI.Tests.V2.UseCase
 
             var request = new SearchAddressRequest
             {
+                Query = _faker.Address.FullAddress(),
                 Postcode = "RM3 0FS",
                 AddressScope = "HackneyGazetteer",
                 Page = _faker.Random.Int(),
@@ -77,7 +78,8 @@ namespace AddressesAPI.Tests.V2.UseCase
                         && x.UsagePrimary == request.UsagePrimary
                         && x.IncludeParentShells == request.IncludeParentShells
                         && x.CrossRefCode == request.CrossRefCode
-                        && x.CrossRefValue == request.CrossRefValue)))
+                        && x.CrossRefValue == request.CrossRefValue
+                        && x.AddressQuery == request.Query)))
                 .ReturnsAsync((new List<string>(), 1)).Verifiable();
 
             _classUnderTest.ExecuteAsync(request);

--- a/AddressesAPI.Tests/V2/UseCase/SearchAddressValidatorTests.cs
+++ b/AddressesAPI.Tests/V2/UseCase/SearchAddressValidatorTests.cs
@@ -305,6 +305,20 @@ namespace AddressesAPI.Tests.V2.UseCase
             _classUnderTest.TestValidate(request).ShouldNotHaveError();
         }
 
+        [TestCase("hackney road")]
+        public void GivenARequestWithOnlyAnAddressQuery_IfAddressScopeIsHackneyGazetteer_WhenCallingValidation_ItReturnsNoError(string query)
+        {
+            var request = new SearchAddressRequest() { Query = query, AddressScope = _localGazetteer };
+            _classUnderTest.TestValidate(request).ShouldNotHaveError();
+        }
+
+        [TestCase("liverpool road")]
+        public void GivenARequestWithOnlyAnAddressQuery_IfAddressScopeIsNational_WhenCallingValidation_ItReturnsNoError(string query)
+        {
+            var request = new SearchAddressRequest() { Query = query, AddressScope = _nationalGazetteer };
+            _classUnderTest.TestValidate(request).ShouldNotHaveError();
+        }
+
         [TestCase("Sesame street")]
         public void GivenARequestWithOnlyAStreet_IfAddressScopeIsHackneyGazetteer_WhenCallingValidation_ItReturnsNoError(string street)
         {
@@ -317,7 +331,7 @@ namespace AddressesAPI.Tests.V2.UseCase
         {
             var request = new SearchAddressRequest() { Street = street, AddressScope = _nationalGazetteer };
             _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage(
-                "You must provide at least one of (uprn, usrn, postcode), when address_scope is 'national'.");
+                "You must provide at least one of (query, uprn, usrn, postcode), when address_scope is 'national'.");
         }
 
         [TestCase("someValue")]
@@ -332,7 +346,7 @@ namespace AddressesAPI.Tests.V2.UseCase
         {
             var request = new SearchAddressRequest() { UsagePrimary = usagePrimary, AddressScope = _nationalGazetteer };
             _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage(
-                "You must provide at least one of (uprn, usrn, postcode), when address_scope is 'national'.");
+                "You must provide at least one of (query, uprn, usrn, postcode), when address_scope is 'national'.");
         }
 
         [TestCase("otherValue")]
@@ -347,7 +361,7 @@ namespace AddressesAPI.Tests.V2.UseCase
         {
             var request = new SearchAddressRequest() { UsageCode = usageCode, AddressScope = _nationalGazetteer };
             _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage(
-                "You must provide at least one of (uprn, usrn, postcode), when address_scope is 'national'.");
+                "You must provide at least one of (query, uprn, usrn, postcode), when address_scope is 'national'.");
         }
 
         [TestCase("12345")]
@@ -355,7 +369,7 @@ namespace AddressesAPI.Tests.V2.UseCase
         {
             var request = new SearchAddressRequest() { BuildingNumber = buildingNumber, AddressScope = _localGazetteer };
             _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage(
-                "You must provide at least one of (uprn, usrn, postcode, street, usagePrimary, usageCode), when address_scope is 'hackney borough' or 'hackney gazetteer'.");
+                "You must provide at least one of (query, uprn, usrn, postcode, street, usagePrimary, usageCode), when address_scope is 'hackney borough' or 'hackney gazetteer'.");
         }
 
         [TestCase("12345")]
@@ -363,7 +377,7 @@ namespace AddressesAPI.Tests.V2.UseCase
         {
             var request = new SearchAddressRequest() { BuildingNumber = buildingNumber, AddressScope = _nationalGazetteer };
             _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage(
-                "You must provide at least one of (uprn, usrn, postcode), when address_scope is 'national'.");
+                "You must provide at least one of (query, uprn, usrn, postcode), when address_scope is 'national'.");
         }
 
         [Test]

--- a/AddressesAPI/Infrastructure/QueryableAddress.cs
+++ b/AddressesAPI/Infrastructure/QueryableAddress.cs
@@ -72,6 +72,10 @@ namespace AddressesAPI.Infrastructure
         [MaxLength(100)]
         public string Line4 { get; set; }
 
+        [MaxLength(700)]
+        [Text(Name = "full_address")]
+        public string FullAddress { get; set; }
+
         [Text(Name = "paon_start_num")]
         public short? PaonStartNumber { get; set; }
         [Text(Name = "unit_number")]

--- a/AddressesAPI/V2/Boundary/Requests/SearchAddressRequest.cs
+++ b/AddressesAPI/V2/Boundary/Requests/SearchAddressRequest.cs
@@ -14,6 +14,11 @@ namespace AddressesAPI.V2.Boundary.Requests
             AddressStatus = "approved";
         }
 
+        ///<summary>
+        /// Query the address text across all address lines. The query will return partial matches and accept some misspelling errors
+        /// </summary>
+        public string Query { get; set; }
+
         /// <summary>
         /// Postcode partial match i.e. "E8 4" will return addresses that have a postcode starting with E84**
         /// (Whitespace is removed automatically)

--- a/AddressesAPI/V2/Domain/SearchParameters.cs
+++ b/AddressesAPI/V2/Domain/SearchParameters.cs
@@ -20,5 +20,6 @@ namespace AddressesAPI.V2.Domain
         public string CrossRefValue { get; set; }
         public int Page { get; set; }
         public int PageSize { get; set; }
+        public string AddressQuery { get; set; }
     }
 }

--- a/AddressesAPI/V2/UseCase/SearchAddressUseCase.cs
+++ b/AddressesAPI/V2/UseCase/SearchAddressUseCase.cs
@@ -77,6 +77,7 @@ namespace AddressesAPI.V2.UseCase
                 UsagePrimary = request.UsagePrimary,
                 OutOfBoroughAddress = addressScope != GlobalConstants.AddressScope.HackneyBorough,
                 IncludeParentShells = request.IncludeParentShells,
+                AddressQuery = request.Query
             };
         }
     }

--- a/AddressesAPI/V2/UseCase/SearchAddressValidator.cs
+++ b/AddressesAPI/V2/UseCase/SearchAddressValidator.cs
@@ -35,11 +35,11 @@ namespace AddressesAPI.V2.UseCase
 
             RuleFor(r => r)
                 .Must(CheckForAtLeastOneMandatoryFilterPropertyWithHackneyGazetteer)
-                .WithMessage("You must provide at least one of (uprn, usrn, postcode, street, usagePrimary, usageCode), when address_scope is 'hackney borough' or 'hackney gazetteer'.");
+                .WithMessage("You must provide at least one of (query, uprn, usrn, postcode, street, usagePrimary, usageCode), when address_scope is 'hackney borough' or 'hackney gazetteer'.");
 
             RuleFor(r => r)
                 .Must(CheckForAtLeastOneMandatoryFilterPropertyWithNationalGazetteer)
-                .WithMessage("You must provide at least one of (uprn, usrn, postcode), when address_scope is 'national'.");
+                .WithMessage("You must provide at least one of (query, uprn, usrn, postcode), when address_scope is 'national'.");
 
             RuleFor(r => r)
                 .Must(CheckCrossReferenceCodeWhenGivenHasAValue)
@@ -76,12 +76,13 @@ namespace AddressesAPI.V2.UseCase
             }
 
             return request.AddressScope.Equals(GlobalConstants.AddressScope.National.ToString(), StringComparison.InvariantCultureIgnoreCase)
-                                              || request.UPRN != null
-                                              || request.USRN != null
-                                              || request.Postcode != null
-                                              || request.Street != null
-                                              || request.UsagePrimary != null
-                                              || request.UsageCode != null;
+                  || request.UPRN != null
+                  || request.USRN != null
+                  || request.Postcode != null
+                  || request.Street != null
+                  || request.UsagePrimary != null
+                  || request.UsageCode != null
+                  || !string.IsNullOrWhiteSpace(request.Query);
         }
 
         private static bool CheckForAtLeastOneMandatoryFilterPropertyWithNationalGazetteer(SearchAddressRequest request)
@@ -89,7 +90,8 @@ namespace AddressesAPI.V2.UseCase
             return !request.AddressScope.Equals(GlobalConstants.AddressScope.National.ToString(), StringComparison.InvariantCultureIgnoreCase)
                    || request.UPRN != null
                    || request.USRN != null
-                   || request.Postcode != null;
+                   || request.Postcode != null
+                   || !string.IsNullOrWhiteSpace(request.Query);
         }
 
         private static bool CheckCrossReferenceCodeWhenGivenHasAValue(SearchAddressRequest request)

--- a/data/elasticsearch/index.json
+++ b/data/elasticsearch/index.json
@@ -10,6 +10,19 @@
           "char_filter": [
             "remove_whitespace"
           ]
+        },
+        "address_text": {
+          "type": "custom",
+          "tokenizer": "classic",
+          "ignore_case": true,
+          "char_filter": [
+            "remove_apostrophes"
+          ],
+          "filter": [
+            "lowercase",
+            "common_street_terms_synonyms",
+            "ignore_unmeaningful_building_words"
+          ]
         }
       },
       "char_filter": {
@@ -17,6 +30,26 @@
           "type": "pattern_replace",
           "pattern": " ",
           "replacement": ""
+        },
+        "remove_apostrophes": {
+          "type": "pattern_replace",
+          "pattern": "'",
+          "replacement": ""
+        }
+      },
+      "filter": {
+        "common_street_terms_synonyms": {
+          "type": "synonym",
+          "ignore_case": true,
+          "lenient": false,
+          "synonyms": [ "road, lane, street, avenue, rd, str, avn, ave, close => road" ]
+        },
+        "ignore_unmeaningful_building_words": {
+          "type": "stop",
+          "ignore_case": true,
+          "stopwords": [
+            "flat"
+          ]
         }
       }
     }
@@ -52,39 +85,27 @@
       },
       "line1" : {
         "type" : "text",
-        "fields" : {
-          "keyword" : {
-            "type" : "keyword",
-            "ignore_above" : 256
-          }
-        }
+        "analyzer": "address_text",
+        "copy_to": "full_address"
       },
       "line2" : {
         "type" : "text",
-        "fields" : {
-          "keyword" : {
-            "type" : "keyword",
-            "ignore_above" : 256
-          }
-        }
+        "analyzer": "address_text",
+        "copy_to": "full_address"
       },
       "line3" : {
         "type" : "text",
-        "fields" : {
-          "keyword" : {
-            "type" : "keyword",
-            "ignore_above" : 256
-          }
-        }
+        "analyzer": "address_text",
+        "copy_to": "full_address"
       },
       "line4" : {
         "type" : "text",
-        "fields" : {
-          "keyword" : {
-            "type" : "keyword",
-            "ignore_above" : 256
-          }
-        }
+        "analyzer": "address_text",
+        "copy_to": "full_address"
+      },
+      "full_address" : {
+        "type" : "text",
+        "analyzer": "address_text"
       },
       "neverexport" : {
         "type" : "boolean"


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/PA-410

## Describe this PR

### *What is the problem we're trying to solve*

We want a free text search on the address lines that will give some allowance for spelling mistakes, incorrect street terms, partial searches etc.

### *What changes have we introduced*

Add a full-text search in elasticsearch which 

- Will search anywhere across all four address lines and return results for which every search term is matched in one of the lines. For example, if you searching 290 Mare Street, the search terms, "290", "Mare" and "street" would have to appear in at least one of the address lines for it to be returned.
- treats common streets terms (road, lane, street, avenue, rd, str, avn, ave, close) as the same. So searching for "Mare Road" would match "Mare Street"
- Allow 0 - 2  mistakes based on the word length of the search term. The first 3 characters in a word must however be correct
- Ignores the word "flat" so searching for "Flat A, 200 Mare Street" would return "200A Mare Street"

When using the query parameter you are not obligated to pass one of the other previously required parameters. 

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Order the results in a way that makes sense, mixing relevance of the query with ordering by town, postcode, street etc.