### PR TITLE
Add option to delete all indices attached to the alias after reindex

### DIFF
--- a/Reindex/ReindexRequest.cs
+++ b/Reindex/ReindexRequest.cs
@@ -14,5 +14,11 @@ namespace Reindex
         /// Optional request parameter. If not supplied it will use the config saved in the data folder of this repository.
         /// </summary>
         public string config { get; set; } = null;
+
+        /// <summary>
+        /// Optional request parameter. If supplied after reindexing, any indexes previously linked to the alias will
+        /// be deleted. Defaults to false.
+        /// </summary>
+        public bool deleteAfterReindex { get; set; } = false;
     }
 }

--- a/Reindex/SqsMessage.cs
+++ b/Reindex/SqsMessage.cs
@@ -5,5 +5,6 @@ namespace Reindex
         public string taskId { get; set; }
         public string newIndex { get; set; }
         public string alias { get; set; }
+        public bool deleteAfterReindex { get; set; }
     }
 }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/PA-417
## Describe this PR

### *What is the problem we're trying to solve*

After the scheduled reindexing, we don't want to keep all indexes around as it will use up space. 

### *What changes have we introduced*

Added a `deleteAfterReindex` flag to the lambda request, if this is set to true all indices that were previously attached to the alias will be deleted.

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly
