### PR TITLE
Get SQS queue ARN using cloud formation

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -48,7 +48,10 @@ functions:
       ELASTICSEARCH_DOMAIN_URL: ${ssm:/addresses-api/${self:provider.stage}/elasticsearch-domain}
     events:
       - sqs:
-          arn: arn:aws:sqs:${self:provider.region}:715003523189:sqs-addresses-api-reindex-${self:provider.stage}
+          arn:
+            Fn::GetAtt:
+              - sqsQueueReindexingAlias
+              - Arn
           batchSize: 1
 resources:
   Resources:


### PR DESCRIPTION
Assign the SQS queue ID using cloudformation instead of hardcoding it.