### PR TITLE
Ordering search results

### DIFF
--- a/AddressesAPI.Tests/V2/Gateways/SearchAddressesGatewayTest.cs
+++ b/AddressesAPI.Tests/V2/Gateways/SearchAddressesGatewayTest.cs
@@ -623,15 +623,13 @@ namespace AddressesAPI.Tests.V2.Gateways
         [Test]
         public async Task WillFirstlyOrderByTown()
         {
-            var addressOne = await TestDataHelper
-                .InsertAddressInEs(ElasticsearchClient, addressConfig: new QueryableAddress { Town = "town a" })
-                .ConfigureAwait(true);
-            var addressTwo = await TestDataHelper
-                .InsertAddressInEs(ElasticsearchClient, addressConfig: new QueryableAddress { Town = "town b" })
-                .ConfigureAwait(true);
-            var addressThree = await TestDataHelper
-                .InsertAddressInEs(ElasticsearchClient, addressConfig: new QueryableAddress { Town = "hackney" })
-                .ConfigureAwait(true);
+            var savedAddresses = new List<QueryableAddress>
+            {
+                new QueryableAddress { Town = "town a" },
+                new QueryableAddress { Town = "town b" },
+                new QueryableAddress { Town = "hackney" }
+            };
+            savedAddresses = await IndexAddresses(savedAddresses).ConfigureAwait(true);
 
             var request = new SearchParameters
             {
@@ -642,23 +640,21 @@ namespace AddressesAPI.Tests.V2.Gateways
             var (addresses, _) = await _classUnderTest.SearchAddresses(request).ConfigureAwait(true);
 
             addresses.Count.Should().Be(3);
-            addresses.ElementAt(0).Should().BeEquivalentTo(addressThree.AddressKey);
-            addresses.ElementAt(1).Should().BeEquivalentTo(addressOne.AddressKey);
-            addresses.ElementAt(2).Should().BeEquivalentTo(addressTwo.AddressKey);
+            addresses.ElementAt(0).Should().BeEquivalentTo(savedAddresses.ElementAt(2).AddressKey);
+            addresses.ElementAt(1).Should().BeEquivalentTo(savedAddresses.ElementAt(0).AddressKey);
+            addresses.ElementAt(2).Should().BeEquivalentTo(savedAddresses.ElementAt(1).AddressKey);
         }
 
         [Test]
         public async Task WillSecondlyOrderByPostcodePresence()
         {
-            var addressOne = await TestDataHelper
-                .InsertAddressInEs(ElasticsearchClient, addressConfig: new QueryableAddress { Town = "town a", Postcode = "" })
-                .ConfigureAwait(true);
-            var addressTwo = await TestDataHelper
-                .InsertAddressInEs(ElasticsearchClient, addressConfig: new QueryableAddress { Town = "town a", Postcode = "E3 4TT" })
-                .ConfigureAwait(true);
-            var addressThree = await TestDataHelper
-                .InsertAddressInEs(ElasticsearchClient, addressConfig: new QueryableAddress { Town = "town b" })
-                .ConfigureAwait(true);
+            var savedAddresses = new List<QueryableAddress>
+            {
+                new QueryableAddress { Town = "town a", Postcode = "" },
+                new QueryableAddress { Town = "town a", Postcode = "E3 4TT" },
+                new QueryableAddress { Town = "town b" }
+            };
+            savedAddresses = await IndexAddresses(savedAddresses).ConfigureAwait(true);
 
             var request = new SearchParameters
             {
@@ -669,23 +665,22 @@ namespace AddressesAPI.Tests.V2.Gateways
             var (addresses, _) = await _classUnderTest.SearchAddresses(request).ConfigureAwait(true);
 
             addresses.Count.Should().Be(3);
-            addresses.ElementAt(0).Should().BeEquivalentTo(addressTwo.AddressKey);
-            addresses.ElementAt(1).Should().BeEquivalentTo(addressOne.AddressKey);
-            addresses.ElementAt(2).Should().BeEquivalentTo(addressThree.AddressKey);
+            addresses.ElementAt(0).Should().BeEquivalentTo(savedAddresses.ElementAt(1).AddressKey);
+            addresses.ElementAt(1).Should().BeEquivalentTo(savedAddresses.ElementAt(0).AddressKey);
+            addresses.ElementAt(2).Should().BeEquivalentTo(savedAddresses.ElementAt(2).AddressKey);
         }
 
         [Test]
         public async Task WillThirdlyOrderByStreet()
         {
-            var addressOne = await TestDataHelper
-                .InsertAddressInEs(ElasticsearchClient, addressConfig: new QueryableAddress { Town = "town b" })
-                .ConfigureAwait(true);
-            var addressTwo = await TestDataHelper
-                .InsertAddressInEs(ElasticsearchClient, addressConfig: new QueryableAddress { Town = "town a", Postcode = "", Street = "B Street" })
-                .ConfigureAwait(true);
-            var addressThree = await TestDataHelper
-                .InsertAddressInEs(ElasticsearchClient, addressConfig: new QueryableAddress { Town = "town a", Postcode = "", Street = "A Street" })
-                .ConfigureAwait(true);
+            var savedAddresses = new List<QueryableAddress>
+            {
+                new QueryableAddress { Town = "town b" },
+                new QueryableAddress { Town = "town a", Postcode = "", Street = "B Street" },
+                new QueryableAddress { Town = "town a", Postcode = "", Street = "A Street" }
+            };
+            savedAddresses = await IndexAddresses(savedAddresses).ConfigureAwait(true);
+
             var request = new SearchParameters
             {
                 Page = 1,
@@ -695,35 +690,22 @@ namespace AddressesAPI.Tests.V2.Gateways
             var (addresses, _) = await _classUnderTest.SearchAddresses(request).ConfigureAwait(true);
 
             addresses.Count.Should().Be(3);
-            addresses.ElementAt(0).Should().BeEquivalentTo(addressThree.AddressKey);
-            addresses.ElementAt(1).Should().BeEquivalentTo(addressTwo.AddressKey);
-            addresses.ElementAt(2).Should().BeEquivalentTo(addressOne.AddressKey);
+            addresses.ElementAt(0).Should().BeEquivalentTo(savedAddresses.ElementAt(2).AddressKey);
+            addresses.ElementAt(1).Should().BeEquivalentTo(savedAddresses.ElementAt(1).AddressKey);
+            addresses.ElementAt(2).Should().BeEquivalentTo(savedAddresses.ElementAt(0).AddressKey);
         }
 
         [Test]
         public async Task WillFourthlyOrderByPresenceAndOrderOfPaonStartNumber()
         {
-            var addressOne = await TestDataHelper.InsertAddressInEs(ElasticsearchClient, addressConfig: new QueryableAddress
+            var savedAddresses = new List<QueryableAddress>
             {
-                Town = "town a",
-                Postcode = "",
-                Street = "B Street",
-                PaonStartNumber = 3
-            }).ConfigureAwait(true);
-            var addressTwo = await TestDataHelper.InsertAddressInEs(ElasticsearchClient, addressConfig: new QueryableAddress
-            {
-                Town = "town a",
-                Postcode = "",
-                Street = "B Street",
-                PaonStartNumber = 0
-            }).ConfigureAwait(true);
-            var addressThree = await TestDataHelper.InsertAddressInEs(ElasticsearchClient, addressConfig: new QueryableAddress
-            {
-                Town = "town a",
-                Postcode = "",
-                Street = "B Street",
-                PaonStartNumber = 5
-            }).ConfigureAwait(true);
+                new QueryableAddress { Town = "town a", Postcode = "", Street = "B Street", PaonStartNumber = 3 },
+                new QueryableAddress {Town = "town a", Postcode = "", Street = "B Street", PaonStartNumber = 0},
+                new QueryableAddress { Town = "town a", Postcode = "", Street = "B Street", PaonStartNumber = 0 }
+            };
+            savedAddresses = await IndexAddresses(savedAddresses).ConfigureAwait(true);
+
             var request = new SearchParameters
             {
                 Page = 1,
@@ -733,38 +715,22 @@ namespace AddressesAPI.Tests.V2.Gateways
             var (addresses, _) = await _classUnderTest.SearchAddresses(request).ConfigureAwait(true);
 
             addresses.Count.Should().Be(3);
-            addresses.ElementAt(0).Should().BeEquivalentTo(addressOne.AddressKey);
-            addresses.ElementAt(1).Should().BeEquivalentTo(addressThree.AddressKey);
-            addresses.ElementAt(2).Should().BeEquivalentTo(addressTwo.AddressKey);
+            addresses.ElementAt(0).Should().BeEquivalentTo(savedAddresses.ElementAt(0).AddressKey);
+            addresses.ElementAt(1).Should().BeEquivalentTo(savedAddresses.ElementAt(2).AddressKey);
+            addresses.ElementAt(2).Should().BeEquivalentTo(savedAddresses.ElementAt(1).AddressKey);
         }
 
         [Test]
         public async Task WillFifthlyOrderByPresenceAndOrderOfBuildingNumber()
         {
-            var addressOne = await TestDataHelper.InsertAddressInEs(ElasticsearchClient, addressConfig: new QueryableAddress
+            var savedAddresses = new List<QueryableAddress>
             {
-                Town = "town a",
-                Postcode = "",
-                Street = "B Street",
-                PaonStartNumber = 1,
-                BuildingNumber = ""
-            }).ConfigureAwait(true);
-            var addressTwo = await TestDataHelper.InsertAddressInEs(ElasticsearchClient, addressConfig: new QueryableAddress
-            {
-                Town = "town a",
-                Postcode = "",
-                Street = "B Street",
-                PaonStartNumber = 1,
-                BuildingNumber = "78"
-            }).ConfigureAwait(true);
-            var addressThree = await TestDataHelper.InsertAddressInEs(ElasticsearchClient, addressConfig: new QueryableAddress
-            {
-                Town = "town a",
-                Postcode = "",
-                Street = "B Street",
-                PaonStartNumber = 1,
-                BuildingNumber = "99"
-            }).ConfigureAwait(true);
+                new QueryableAddress { Town = "town a", Postcode = "", Street = "B Street", PaonStartNumber = 1, BuildingNumber = "" },
+                new QueryableAddress { Town = "town a", Postcode = "", Street = "B Street", PaonStartNumber = 1, BuildingNumber = "78" },
+                new QueryableAddress { Town = "town a", Postcode = "", Street = "B Street", PaonStartNumber = 1, BuildingNumber = "99" }
+            };
+            savedAddresses = await IndexAddresses(savedAddresses).ConfigureAwait(true);
+
             var request = new SearchParameters
             {
                 Page = 1,
@@ -774,41 +740,43 @@ namespace AddressesAPI.Tests.V2.Gateways
             var (addresses, _) = await _classUnderTest.SearchAddresses(request).ConfigureAwait(true);
 
             addresses.Count.Should().Be(3);
-            addresses.ElementAt(0).Should().BeEquivalentTo(addressTwo.AddressKey);
-            addresses.ElementAt(1).Should().BeEquivalentTo(addressThree.AddressKey);
-            addresses.ElementAt(2).Should().BeEquivalentTo(addressOne.AddressKey);
+            addresses.ElementAt(0).Should().BeEquivalentTo(savedAddresses.ElementAt(1).AddressKey);
+            addresses.ElementAt(1).Should().BeEquivalentTo(savedAddresses.ElementAt(2).AddressKey);
+            addresses.ElementAt(2).Should().BeEquivalentTo(savedAddresses.ElementAt(0).AddressKey);
         }
 
         [Test]
         public async Task WillSixthOrderByPresenceAndOrderOfUnitNumber()
         {
-            var addressOne = await TestDataHelper.InsertAddressInEs(ElasticsearchClient, addressConfig: new QueryableAddress
+            var savedAddresses = new List<QueryableAddress>
             {
-                Town = "town a",
-                Postcode = "",
-                Street = "B Street",
-                PaonStartNumber = 1,
-                BuildingNumber = "78",
-                UnitNumber = "43"
-            }).ConfigureAwait(true);
-            var addressTwo = await TestDataHelper.InsertAddressInEs(ElasticsearchClient, addressConfig: new QueryableAddress
-            {
-                Town = "town a",
-                Postcode = "",
-                Street = "B Street",
-                PaonStartNumber = 1,
-                BuildingNumber = "78",
-                UnitNumber = ""
-            }).ConfigureAwait(true);
-            var addressThree = await TestDataHelper.InsertAddressInEs(ElasticsearchClient, addressConfig: new QueryableAddress
-            {
-                Town = "town a",
-                Postcode = "",
-                Street = "B Street",
-                PaonStartNumber = 1,
-                BuildingNumber = "78",
-                UnitNumber = "23"
-            }).ConfigureAwait(true);
+                new QueryableAddress {
+                    Town = "town a",
+                    Postcode = "",
+                    Street = "B Street",
+                    PaonStartNumber = 1,
+                    BuildingNumber = "78",
+                    UnitNumber = "43"
+                },
+                new QueryableAddress {
+                    Town = "town a",
+                    Postcode = "",
+                    Street = "B Street",
+                    PaonStartNumber = 1,
+                    BuildingNumber = "78",
+                    UnitNumber = ""
+                },
+                new QueryableAddress {
+                    Town = "town a",
+                    Postcode = "",
+                    Street = "B Street",
+                    PaonStartNumber = 1,
+                    BuildingNumber = "78",
+                    UnitNumber = "23"
+                }
+            };
+            savedAddresses = await IndexAddresses(savedAddresses).ConfigureAwait(true);
+
             var request = new SearchParameters
             {
                 Page = 1,
@@ -818,44 +786,46 @@ namespace AddressesAPI.Tests.V2.Gateways
             var (addresses, _) = await _classUnderTest.SearchAddresses(request).ConfigureAwait(true);
 
             addresses.Count.Should().Be(3);
-            addresses.ElementAt(0).Should().BeEquivalentTo(addressThree.AddressKey);
-            addresses.ElementAt(1).Should().BeEquivalentTo(addressOne.AddressKey);
-            addresses.ElementAt(2).Should().BeEquivalentTo(addressTwo.AddressKey);
+            addresses.ElementAt(0).Should().BeEquivalentTo(savedAddresses.ElementAt(2).AddressKey);
+            addresses.ElementAt(1).Should().BeEquivalentTo(savedAddresses.ElementAt(0).AddressKey);
+            addresses.ElementAt(2).Should().BeEquivalentTo(savedAddresses.ElementAt(1).AddressKey);
         }
 
         [Test]
         public async Task WillInTheSeventhCaseOrderByPresenceAndOrderOfUnitName()
         {
-            var addressOne = await TestDataHelper.InsertAddressInEs(ElasticsearchClient, addressConfig: new QueryableAddress
+            var savedAddresses = new List<QueryableAddress>
             {
-                Town = "town a",
-                Postcode = "",
-                Street = "B Street",
-                PaonStartNumber = 1,
-                BuildingNumber = "78",
-                UnitNumber = "43",
-                UnitName = "J name"
-            }).ConfigureAwait(true);
-            var addressTwo = await TestDataHelper.InsertAddressInEs(ElasticsearchClient, addressConfig: new QueryableAddress
-            {
-                Town = "town a",
-                Postcode = "",
-                Street = "B Street",
-                PaonStartNumber = 1,
-                BuildingNumber = "78",
-                UnitNumber = "43",
-                UnitName = "A name"
-            }).ConfigureAwait(true);
-            var addressThree = await TestDataHelper.InsertAddressInEs(ElasticsearchClient, addressConfig: new QueryableAddress
-            {
-                Town = "town a",
-                Postcode = "",
-                Street = "B Street",
-                PaonStartNumber = 1,
-                BuildingNumber = "78",
-                UnitNumber = "43",
-                UnitName = ""
-            }).ConfigureAwait(true);
+                new QueryableAddress {
+                    Town = "town a",
+                    Postcode = "",
+                    Street = "B Street",
+                    PaonStartNumber = 1,
+                    BuildingNumber = "78",
+                    UnitNumber = "43",
+                    UnitName = "J name"
+                },
+                new QueryableAddress {
+                    Town = "town a",
+                    Postcode = "",
+                    Street = "B Street",
+                    PaonStartNumber = 1,
+                    BuildingNumber = "78",
+                    UnitNumber = "43",
+                    UnitName = "A name"
+                },
+                new QueryableAddress {
+                    Town = "town a",
+                    Postcode = "",
+                    Street = "B Street",
+                    PaonStartNumber = 1,
+                    BuildingNumber = "78",
+                    UnitNumber = "43",
+                    UnitName = ""
+                }
+            };
+            savedAddresses = await IndexAddresses(savedAddresses).ConfigureAwait(true);
+
             var request = new SearchParameters
             {
                 Page = 1,
@@ -865,11 +835,23 @@ namespace AddressesAPI.Tests.V2.Gateways
             var (addresses, _) = await _classUnderTest.SearchAddresses(request).ConfigureAwait(true);
 
             addresses.Count.Should().Be(3);
-            addresses.ElementAt(0).Should().BeEquivalentTo(addressTwo.AddressKey);
-            addresses.ElementAt(1).Should().BeEquivalentTo(addressOne.AddressKey);
-            addresses.ElementAt(2).Should().BeEquivalentTo(addressThree.AddressKey);
+            addresses.ElementAt(0).Should().BeEquivalentTo(savedAddresses.ElementAt(1).AddressKey);
+            addresses.ElementAt(1).Should().BeEquivalentTo(savedAddresses.ElementAt(0).AddressKey);
+            addresses.ElementAt(2).Should().BeEquivalentTo(savedAddresses.ElementAt(2).AddressKey);
         }
 
+        private async Task<List<QueryableAddress>> IndexAddresses(IEnumerable<QueryableAddress> addresses)
+        {
+            var newAddresses = new List<QueryableAddress>();
+            foreach (var queryableAddress in addresses)
+            {
+                newAddresses.Add(await TestDataHelper
+                    .InsertAddressInEs(ElasticsearchClient, addressConfig: queryableAddress)
+                    .ConfigureAwait(true));
+            }
+
+            return newAddresses;
+        }
         #endregion
 
         #region pagination

--- a/AddressesAPI/V2/Gateways/AddressesGateway.cs
+++ b/AddressesAPI/V2/Gateways/AddressesGateway.cs
@@ -1,11 +1,7 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 using AddressesAPI.Infrastructure;
-using AddressesAPI.V2.Domain;
 using AddressesAPI.V2.Factories;
-using Microsoft.EntityFrameworkCore;
 using Address = AddressesAPI.Infrastructure.Address;
 
 namespace AddressesAPI.V2.Gateways
@@ -36,60 +32,6 @@ namespace AddressesAPI.V2.Gateways
                 .ToList();
         }
 
-        private IQueryable<Address> GetParentShells(IQueryable<Address> baseQuery, IQueryable<Address> baseAddresses)
-        {
-            var childShells = baseQuery;
-            while (true)
-            {
-                var parentUprns = GetImmediateParentUprns(childShells);
-                if (!parentUprns.Any()) break;
-                var parentShells = GetImmediateParentShells(parentUprns, ref baseAddresses);
-                childShells = parentShells;
-            }
-
-            return baseAddresses;
-        }
-
-        private static IQueryable<long?> GetImmediateParentUprns(IQueryable<Address> childShells)
-        {
-            return childShells.Select(a => a.ParentUPRN)
-                .Where(pu => pu != null && pu != 0)
-                .Distinct();
-        }
-
-        private IQueryable<Address> GetImmediateParentShells(IQueryable<long?> parentUprns, ref IQueryable<Address> baseAddresses)
-        {
-            var parentShells = _addressesContext.Addresses.Where(ps => parentUprns.Contains(ps.UPRN));
-            baseAddresses = baseAddresses.Union(parentShells);
-            return parentShells;
-        }
-
-        private static IQueryable<Address> PageAddresses(IQueryable<Address> query,
-            int pageSize, int page)
-        {
-            var pageOffset = pageSize * (page == 0 ? 0 : page - 1);
-
-            return query.Skip(pageOffset)
-                .Take(pageSize);
-        }
-
-        private static IQueryable<Address> OrderAddresses(IQueryable<Address> query)
-        {
-            return query.OrderBy(a => a.Town)
-                .ThenBy(a => a.Postcode == null)
-                .ThenBy(a => a.Postcode)
-                .ThenBy(a => a.Street)
-                .ThenBy(a => a.PaonStartNumber == null)
-                .ThenBy(a => a.PaonStartNumber == 0)
-                .ThenBy(a => a.PaonStartNumber)
-                .ThenBy(a => a.BuildingNumber == null)
-                .ThenBy(a => a.BuildingNumber)
-                .ThenBy(a => a.UnitNumber == null)
-                .ThenBy(a => a.UnitNumber)
-                .ThenBy(a => a.UnitName == null)
-                .ThenBy(a => a.UnitName);
-        }
-
         public List<long> GetMatchingCrossReferenceUprns(string code, string value)
         {
             return _addressesContext.AddressCrossReferences
@@ -97,61 +39,6 @@ namespace AddressesAPI.V2.Gateways
                 .Where(cr => cr.Value == value)
                 .Select(cr => cr.UPRN)
                 .ToList();
-        }
-
-
-        private IQueryable<Address> CompileBaseSearchQuery(SearchParameters request)
-        {
-            var queryByCrossReference = string.IsNullOrWhiteSpace(request.CrossRefCode) && string.IsNullOrWhiteSpace(request.CrossRefValue);
-
-            var addresses = queryByCrossReference
-                ? _addressesContext.Addresses
-                : _addressesContext.Addresses.Where(a => GetMatchingCrossReferenceUprns(request.CrossRefCode, request.CrossRefValue).Contains(a.UPRN));
-
-            var postcodeSearchTerm = request.Postcode == null ? null : $"{request.Postcode.Replace(" ", "")}%";
-            var buildingNumberSearchTerm = GenerateSearchTerm(request.BuildingNumber);
-            var streetSearchTerm = GenerateSearchTerm(request.Street);
-            var addressStatusQuery = (request.AddressStatus?.Select(a => a.ToLower()) ?? new[] { "approved" }).ToList();
-            var addressStatusSearchTerms = addressStatusQuery.Contains("approved")
-                ? addressStatusQuery.Append("approved preferred")
-                : addressStatusQuery;
-            var usageSearchTerms = request.UsagePrimary?.Split(',').ToList();
-            var usageCodeSearchTerms = request.UsageCode?.Split(',').ToList();
-
-            var queryResults = addresses
-                .Where(a => string.IsNullOrWhiteSpace(request.Postcode)
-                            || EF.Functions.ILike(a.Postcode.Replace(" ", ""), postcodeSearchTerm))
-                .Where(a => string.IsNullOrWhiteSpace(request.BuildingNumber)
-                            || EF.Functions.ILike(a.BuildingNumber, buildingNumberSearchTerm))
-                .Where(a => string.IsNullOrWhiteSpace(request.Street) ||
-                            EF.Functions.ILike(a.Street.Replace(" ", ""), streetSearchTerm))
-                .Where(a => addressStatusSearchTerms == null ||
-                            addressStatusSearchTerms.Contains(a.AddressStatus.ToLower()))
-                .Where(a => request.Uprn == null || a.UPRN == request.Uprn)
-                .Where(a => request.Usrn == null
-                            || a.USRN == request.Usrn)
-                .Where(a => (usageSearchTerms == null || !usageSearchTerms.Any())
-                            || usageSearchTerms.Contains(a.UsagePrimary))
-                .WhereAny(usageCodeSearchTerms?.Select(u =>
-                        (Expression<Func<Address, bool>>) (x =>
-                            EF.Functions.ILike(x.UsageCode, $"%{u}%")))
-                    .ToArray())
-                .Where(a => request.IncludeParentShells || !a.PropertyShell)
-                .Where(a => request.Gazetteer == GlobalConstants.Gazetteer.Both
-                            || EF.Functions.ILike(a.Gazetteer, request.Gazetteer.ToString())
-                            || request.Gazetteer == GlobalConstants.Gazetteer.Hackney
-                            && EF.Functions.ILike(a.Gazetteer, "local")
-                )
-                .Where(a => request.OutOfBoroughAddress
-                            || !(EF.Functions.ILike(a.Gazetteer, "national") || a.OutOfBoroughAddress)
-                );
-            return queryResults;
-        }
-
-        private static string GenerateSearchTerm(string request)
-        {
-            if (request == null) return null;
-            return $"%{request.Replace(" ", "")}%";
         }
     }
 }

--- a/AddressesAPI/V2/Gateways/ElasticGateway.cs
+++ b/AddressesAPI/V2/Gateways/ElasticGateway.cs
@@ -135,18 +135,25 @@ namespace AddressesAPI.V2.Gateways
                 .Query(request.AddressQuery)
             );
 
-            return fuzzyMatchText && exactlyMatchNumbers;
+            var exactMatch = q.Match(m => m
+                .Field("full_address.exact_text")
+                .Analyzer("standard")
+                .Query(request.AddressQuery)
+                .Operator(Operator.And));
+
+            return (fuzzyMatchText && exactlyMatchNumbers) || (exactMatch);
         }
 
         private static SortDescriptor<QueryableAddress> SortResults(SortDescriptor<QueryableAddress> srt)
         {
             return srt
+                .Descending(SortSpecialField.Score)
                 .Ascending(f => f.Town)
                 .Field(f => f.Field(n => n.Postcode).Missing("_last"))
                 .Ascending(f => f.Street)
-                .Field(f => f.Field(n => n.PaonStartNumber).Ascending().Missing("_last"))
-                .Field(f => f.Field(n => n.BuildingNumber).Ascending().Missing("_last"))
-                .Field(f => f.Field(n => n.UnitNumber).Ascending().Missing("_last"))
+                .Field(f => f.Field("paon_start_num.sort").Ascending().Missing("_last"))
+                .Field(f => f.Field("building_number.sort").Ascending().Missing("_last"))
+                .Field(f => f.Field("unit_number.sort").Ascending().Missing("_last"))
                 .Field(f => f.Field(n => n.UnitName).Ascending().Missing("_last"));
         }
 

--- a/data/elasticsearch/Dockerfile
+++ b/data/elasticsearch/Dockerfile
@@ -1,0 +1,2 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:7.9.3
+RUN bin/elasticsearch-plugin install --batch analysis-icu

--- a/data/elasticsearch/index.json
+++ b/data/elasticsearch/index.json
@@ -45,7 +45,6 @@
       "filter": {
         "common_street_terms_synonyms": {
           "type": "synonym",
-          "ignore_case": true,
           "lenient": false,
           "synonyms": [ "road, raod, lane, lanes, street, streat, avenue, rd, str, avn, ave, close => road" ]
         },
@@ -90,7 +89,15 @@
         }
       },
       "building_number" : {
-        "type" : "keyword"
+        "type" : "keyword",
+        "fields": {
+          "sort": {
+            "type": "icu_collation_keyword",
+            "index": false,
+            "numeric": true,
+            "case_level": false
+          }
+        }
       },
       "gazetteer" : {
         "type" : "text",
@@ -124,10 +131,17 @@
       "full_address" : {
         "type" : "text",
         "analyzer": "address_text",
+        "similarity": "boolean",
         "fields": {
           "extracted_numbers": {
             "type": "text",
-            "analyzer": "extract_number_analyzer"
+            "analyzer": "extract_number_analyzer",
+            "similarity": "boolean"
+          },
+          "exact_text": {
+            "type" : "text",
+            "analyzer": "standard",
+            "similarity": "boolean"
           }
         }
       },
@@ -135,7 +149,15 @@
         "type" : "boolean"
       },
       "paon_start_num" : {
-        "type" : "keyword"
+        "type" : "keyword",
+        "fields": {
+          "sort": {
+            "type": "icu_collation_keyword",
+            "index": false,
+            "numeric": true,
+            "case_level": false
+          }
+        }
       },
       "parent_uprn" : {
         "type" : "long"
@@ -166,7 +188,15 @@
         "type" : "keyword"
       },
       "unit_number" : {
-        "type" : "keyword"
+        "type" : "keyword",
+        "fields": {
+          "sort": {
+            "type": "icu_collation_keyword",
+            "index": false,
+            "numeric": true,
+            "case_level": false
+          }
+        }
       },
       "blpu_class" : {
         "type" : "text",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,8 +66,11 @@ services:
     networks:
       - postgres
   test-elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.9.3
+    image: test-elasticsearch
     container_name: test-elasticsearch
+    build:
+      context: .
+      dockerfile: data/elasticsearch/Dockerfile
     environment:
       - xpack.security.enabled=false
       - discovery.type=single-node


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/PA-412
## Describe this PR

### *What is the problem we're trying to solve*

Ensure results are ordered logically. Results that are only partially or fuzzily matched should appear further down the results list than other results. 

### *What changes have we introduced*

- Elasticsearch similarity scoring method has been changed to "boolean" which means a score will be assigned to the document if it is a match and it will be the same for any documents that do match. This prevents documents from getting higher scores if a search term appears twice in the address.

- Alongside the fuzzy match we also perform an exact match that only "should" be matched. This will boost the scores of the documents that match the search terms exactly, whilst still returning those that don't.

- Add a "sort" subfield for fields which need to be sorted numerically. For example, if we have 2, 10, 35 as building numbers previously this was being sorted as 10, 2, 35, which is alphabetical. We are using the [ICU analysis](https://www.elastic.co/guide/en/elasticsearch/plugins/current/analysis-icu.html) plugin to achieve this.

- Removed some leftover code from the search method in postgres.

#### _Checklist_

- [x] Added tests to cover all new production code
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Through testing of search results ordering.
