### PR TITLE
Remove message from queue if task can't be found

### DIFF
--- a/Reindex/Handler.cs
+++ b/Reindex/Handler.cs
@@ -94,10 +94,12 @@ namespace Reindex
             var data = JsonConvert.DeserializeObject<SqsMessage>(message);
             LambdaLogger.Log($"Received SQS message {message}");
             var task = await _elasticSearchClient.Tasks.GetTaskAsync(new TaskId(data.taskId));
+            LambdaLogger.Log(JsonConvert.SerializeObject(task));
 
+            if (task.ApiCall.HttpStatusCode == 404) return;
             if (!task.Completed)
             {
-                LambdaLogger.Log("Task has not completed: re-adding message to queue with 10 minute delay");
+                LambdaLogger.Log("Task has not completed: re-adding message to queue");
                 var sqsResponse = await SendSqsMessageToQueue(message);
                 LambdaLogger.Log($"Re-sent task ID to sqs queue messageId: {sqsResponse.MessageId}");
                 return;

--- a/serverless.yml
+++ b/serverless.yml
@@ -31,7 +31,7 @@ functions:
     name: ${self:service}-reindex-es-alias-${self:provider.stage}
     handler: Reindex::Reindex.Handler::ReindexAlias
     role: lambdaExecutionRole
-    timeout: 20
+    timeout: 60
     package:
       artifact: ./Reindex/bin/release/netcoreapp3.1/reindex-es-alias.zip
     environment:
@@ -41,6 +41,7 @@ functions:
     name: ${self:service}-switch-es-alias-after-reindex-${self:provider.stage}
     handler: Reindex::Reindex.Handler::SwitchAlias
     role: lambdaExecutionRole
+    timeout: 30
     package:
       artifact: ./Reindex/bin/release/netcoreapp3.1/reindex-es-alias.zip
     environment:


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

If a lambda timed out or returned an error code, it would both re-add the SQS message to the queue. Because we also do this manually this means that sometimes there were two messages on the queue for the same task, one of them would remove the task and the other would continuously look for a task that didn't exist.

### *What changes have we introduced*

If the task can't be found, the lambda function will successfully return from the function causing the queue message to be removed. 
The timeouts have also been increased as they often timeout on the first run after deployment. 

#### _Checklist_

- [x] Added tests to cover all new production code
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly
