### PR TITLE
Rank ordered search terms higher

### DIFF
--- a/AddressesAPI.Tests/V2/Gateways/SearchAddressesGatewayTest.cs
+++ b/AddressesAPI.Tests/V2/Gateways/SearchAddressesGatewayTest.cs
@@ -749,6 +749,56 @@ namespace AddressesAPI.Tests.V2.Gateways
         }
 
         [Test]
+        public async Task ItWillOrderMatchesInTheCorrectOrderOverMatchesWillSearchTermsSpreadOut()
+        {
+            var savedAddresses = new List<QueryableAddress>
+            {
+                new QueryableAddress
+                {
+                    Street = "ETON COLLEGE ROAD",
+                    Line1 = "FLAT 12",
+                    Line2 = " ETON RISE",
+                    Line3 = " ETON COLLEGE ROAD",
+                    Line4 = "LONDON",
+                    PaonStartNumber = null,
+                    UnitNumber = "12",
+                    UnitName = "Flat 12",
+                    BuildingNumber = "",
+                    Town = "LONDON",
+                    Postcode = "NW3 2DE"
+                },
+                new QueryableAddress
+                {
+                    Street = "READING LANE",
+                    Line1 = "FLAT A",
+                    Line2 = "12 ETON ROAD",
+                    PaonStartNumber = 12,
+                    UnitNumber = null,
+                    UnitName = "A",
+                    BuildingNumber = "12",
+                    Line3 = "LONDON",
+                    Line4 = "NW3 4SS",
+                    Town = "LONDON",
+                    Postcode = "NW3 4SS"
+                },
+            };
+            savedAddresses = await IndexAddresses(savedAddresses).ConfigureAwait(true);
+
+            var request = new SearchParameters
+            {
+                Page = 1,
+                PageSize = 50,
+                Gazetteer = GlobalConstants.Gazetteer.Both,
+                AddressQuery = "12 eton road"
+            };
+            var (addresses, _) = await _classUnderTest.SearchAddresses(request).ConfigureAwait(true);
+
+            addresses.Count.Should().Be(2);
+            addresses.ElementAt(0).Should().BeEquivalentTo(savedAddresses.ElementAt(1).AddressKey);
+            addresses.ElementAt(1).Should().BeEquivalentTo(savedAddresses.ElementAt(0).AddressKey);
+        }
+
+        [Test]
         public async Task WillFirstlyOrderByTown()
         {
             var savedAddresses = new List<QueryableAddress>

--- a/AddressesAPI/V2/Gateways/ElasticGateway.cs
+++ b/AddressesAPI/V2/Gateways/ElasticGateway.cs
@@ -140,8 +140,12 @@ namespace AddressesAPI.V2.Gateways
                 .Analyzer("standard")
                 .Query(request.AddressQuery)
                 .Operator(Operator.And));
+            var orderedMatch = q.Match(m => m
+                .Field("full_address.keyword")
+                .Analyzer("whitespace_removed")
+                .Query(request.AddressQuery));
 
-            return (fuzzyMatchText && exactlyMatchNumbers) || (exactMatch);
+            return (fuzzyMatchText && exactlyMatchNumbers) || (exactMatch) || orderedMatch;
         }
 
         private static SortDescriptor<QueryableAddress> SortResults(SortDescriptor<QueryableAddress> srt)

--- a/data/elasticsearch/index.json
+++ b/data/elasticsearch/index.json
@@ -142,6 +142,10 @@
             "type" : "text",
             "analyzer": "standard",
             "similarity": "boolean"
+          },
+          "keyword": {
+            "type" : "text",
+            "analyzer" : "whitespace_removed"
           }
         }
       },


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/PA-412
## Describe this PR

### *What is the problem we're trying to solve*

Addresses which have your search terms, ordered how you searched for them should be ranked higher than those that don't.
### *What changes have we introduced*
Introduce a keyword search term, as only "should" matching so that it will boost the relevance score if search terms are ordered correctly.

#### _Checklist_
- [x] Added tests to cover all new production code
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Check this doesn't make the search too slow
