### PR TITLE
Add RDS cloudwatch alarms

### DIFF
--- a/terraform/production/alarms.tf
+++ b/terraform/production/alarms.tf
@@ -1,0 +1,39 @@
+/*    CLOUDWATCH ALARM SET UP    */
+
+data "aws_sns_topic" "platform_apis" {
+  name = "Platform-APIs-Alerts"
+}
+
+resource "aws_cloudwatch_metric_alarm" "address_api_db_transactions_log_disk_usage" {
+  alarm_name          = "address-api-db-transactions-log-disk-usage-too-high"
+  alarm_description   = "Average database transactions log disk usage higher than threshold in the last 5 minutes"
+  alarm_actions       = ["${data.aws_sns_topic.platform_apis.arn}"]
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = "40000" # Unit: MB
+  evaluation_periods  = "1"
+  metric_name         = "TransactionLogsDiskUsage"
+  namespace           = "RDS"
+  period              = "300"
+  statistic           = "Average"
+
+  dimensions = {
+    DBInstanceIdentifier = "${module.postgres_db_production.instance_id}"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "address_api_db_free_storage_space" {
+  alarm_name          = "address-api-db-free-storage-space-too-low"
+  alarm_description   = "Average database free storage space log lower than threshold in the last 5 minutes"
+  alarm_actions       = ["${data.aws_sns_topic.platform_apis.arn}"]
+  comparison_operator = "LessThanThreshold"
+  threshold           = "40000" # Unit: MB
+  evaluation_periods  = "1"
+  metric_name         = "FreeStorageSpace"
+  namespace           = "RDS"
+  period              = "300"
+  statistic           = "Average"
+
+  dimensions = {
+    DBInstanceIdentifier = "${module.postgres_db_production.instance_id}"
+  }
+}

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -78,46 +78,6 @@ module "postgres_db_production" {
   project_name         = "platform apis"
 }
 
-/*    CLOUDWATCH ALARM SET UP    */
-
-data "aws_sns_topic" "platform_apis" {
-  name = "Platform-APIs-Alerts"
-}
-
-resource "aws_cloudwatch_metric_alarm" "database-transactions-log-disk-usage" {
-  alarm_name          = "database-transactions-log-disk-usage"
-  alarm_description   = "This metric monitors transactions log disk usage goes above a threshold"
-  alarm_actions       = ["${data.aws_sns_topic.platform_apis.arn}"]
-  comparison_operator = "GreaterThanThreshold"
-  threshold           = "3000"
-  evaluation_periods  = "1"
-  metric_name         = "TransactionLogsDiskUsage"
-  namespace           = "RDS"
-  period              = "300"
-  statistic           = "Average"
-
-  dimensions = {
-    DBInstanceIdentifier = "${module.postgres_db_production.instance_id}"
-  }
-}
-
-resource "aws_cloudwatch_metric_alarm" "free_storage_space_too_low" {
-  alarm_name          = "free-storage-space-too-low"
-  alarm_description   = "Average database free storage space too low within the last 5 minutes"
-  alarm_actions       = ["${data.aws_sns_topic.platform_apis.arn}"]
-  comparison_operator = "LessThanThreshold"
-  threshold           = "40000"
-  evaluation_periods  = "1"
-  metric_name         = "FreeStorageSpace"
-  namespace           = "RDS"
-  period              = "300"
-  statistic           = "Average"
-
-  dimensions = {
-    DBInstanceIdentifier = "${module.postgres_db_production.instance_id}"
-  }
-}
-
 /*    ELASTICSEARCH SETUP    */
 
 module "elasticsearch_db_production" {

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -30,17 +30,17 @@ terraform {
 /*    VPC SET UP    */
 
 data "aws_vpc" "production_vpc" {
-    tags = {
-        Name = "vpc-production-apis-production"
-    }
+  tags = {
+    Name = "vpc-production-apis-production"
+  }
 }
 
 data "aws_subnet_ids" "production" {
-    vpc_id = data.aws_vpc.production_vpc.id
-    filter {
-        name   = "tag:Type"
-        values = ["private"]
-    }
+  vpc_id = data.aws_vpc.production_vpc.id
+  filter {
+    name   = "tag:Type"
+    values = ["private"]
+  }
 }
 
 /*    POSTGRES SET UP    */
@@ -54,7 +54,7 @@ data "aws_ssm_parameter" "addresses_postgres_username" {
 }
 
 data "aws_ssm_parameter" "addresses_postgres_hostname" {
-    name = "/addresses-api/production/postgres-hostname"
+  name = "/addresses-api/production/postgres-hostname"
 }
 
 module "postgres_db_production" {
@@ -78,52 +78,92 @@ module "postgres_db_production" {
   project_name         = "platform apis"
 }
 
+/*    CLOUDWATCH ALARM SET UP    */
+
+data "aws_sns_topic" "platform_apis" {
+  name = "Platform-APIs-Alerts"
+}
+
+resource "aws_cloudwatch_metric_alarm" "database-transactions-log-disk-usage" {
+  alarm_name          = "database-transactions-log-disk-usage"
+  alarm_description   = "This metric monitors transactions log disk usage goes above a threshold"
+  alarm_actions       = ["${data.aws_sns_topic.platform_apis.arn}"]
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = "3000"
+  evaluation_periods  = "1"
+  metric_name         = "TransactionLogsDiskUsage"
+  namespace           = "RDS"
+  period              = "300"
+  statistic           = "Average"
+
+  dimensions = {
+    DBInstanceIdentifier = "${module.postgres_db_production.instance_id}"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "free_storage_space_too_low" {
+  alarm_name          = "free-storage-space-too-low"
+  alarm_description   = "Average database free storage space too low within the last 5 minutes"
+  alarm_actions       = ["${data.aws_sns_topic.platform_apis.arn}"]
+  comparison_operator = "LessThanThreshold"
+  threshold           = "40000"
+  evaluation_periods  = "1"
+  metric_name         = "FreeStorageSpace"
+  namespace           = "RDS"
+  period              = "300"
+  statistic           = "Average"
+
+  dimensions = {
+    DBInstanceIdentifier = "${module.postgres_db_production.instance_id}"
+  }
+}
+
 /*    ELASTICSEARCH SETUP    */
 
 module "elasticsearch_db_production" {
-    source = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/elasticsearch"
-    vpc_id= data.aws_vpc.production_vpc.id
-    environment_name= "production"
-    port= 443
-    domain_name= "addresses-api-es"
-    subnet_ids= [tolist(data.aws_subnet_ids.production.ids)[0]]
-    project_name= "addresses-api"
-    es_version= "7.8"
-    encrypt_at_rest= "true"
-    instance_type= "t3.small.elasticsearch"
-    ebs_enabled= "true"
-    ebs_volume_size= "10"
-    region= data.aws_region.current.name
-    account_id= data.aws_caller_identity.current.account_id
+  source           = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/database/elasticsearch"
+  vpc_id           = data.aws_vpc.production_vpc.id
+  environment_name = "production"
+  port             = 443
+  domain_name      = "addresses-api-es"
+  subnet_ids       = [tolist(data.aws_subnet_ids.production.ids)[0]]
+  project_name     = "addresses-api"
+  es_version       = "7.8"
+  encrypt_at_rest  = "true"
+  instance_type    = "t3.small.elasticsearch"
+  ebs_enabled      = "true"
+  ebs_volume_size  = "10"
+  region           = data.aws_region.current.name
+  account_id       = data.aws_caller_identity.current.account_id
 }
 
 data "aws_ssm_parameter" "addresses_elasticsearch_domain" {
-    name = "/addresses-api/production/elasticsearch-domain"
+  name = "/addresses-api/production/elasticsearch-domain"
 }
 
 /*    DMS SETUP    */
 data "aws_iam_policy_document" "dms-assume-role-policy" {
-    statement {
-        actions = ["sts:AssumeRole"]
+  statement {
+    actions = ["sts:AssumeRole"]
 
-        principals {
-            type        = "Service"
-            identifiers = ["dms.amazonaws.com"]
-        }
+    principals {
+      type        = "Service"
+      identifiers = ["dms.amazonaws.com"]
     }
+  }
 }
 
 resource "aws_iam_role" "dms_service_role" {
-    name               = "dms_service_role"
-    path               = "/system/"
-    assume_role_policy = data.aws_iam_policy_document.dms-assume-role-policy.json
+  name               = "dms_service_role"
+  path               = "/system/"
+  assume_role_policy = data.aws_iam_policy_document.dms-assume-role-policy.json
 }
 
 resource "aws_iam_policy" "es_policy" {
-    name        = "DMS_Elasticsearch_Addresses"
-    description = "A policy allowing you CRUD operations on addresses API elasticsearch cluster"
+  name        = "DMS_Elasticsearch_Addresses"
+  description = "A policy allowing you CRUD operations on addresses API elasticsearch cluster"
 
-    policy = <<EOF
+  policy = <<EOF
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -144,54 +184,54 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "attach_policy" {
-    role       = aws_iam_role.dms_service_role.name
-    policy_arn = aws_iam_policy.es_policy.arn
+  role       = aws_iam_role.dms_service_role.name
+  policy_arn = aws_iam_policy.es_policy.arn
 }
 
 
 resource "aws_dms_endpoint" "address_elasticsearch" {
-    endpoint_id   = "target-addresses-es"
-    endpoint_type = "target"
-    engine_name   = "elasticsearch"
-    port          = 443
-    ssl_mode      = "none"
+  endpoint_id   = "target-addresses-es"
+  endpoint_type = "target"
+  engine_name   = "elasticsearch"
+  port          = 443
+  ssl_mode      = "none"
 
-    elasticsearch_settings {
-        endpoint_uri            = data.aws_ssm_parameter.addresses_elasticsearch_domain.value
-        service_access_role_arn = aws_iam_role.dms_service_role.arn
-    }
+  elasticsearch_settings {
+    endpoint_uri            = data.aws_ssm_parameter.addresses_elasticsearch_domain.value
+    service_access_role_arn = aws_iam_role.dms_service_role.arn
+  }
 
-    tags = {
-        Name         = "target-addresses-es",
-        Environment  = "production",
-        project_name = "addresses-api"
-    }
+  tags = {
+    Name         = "target-addresses-es",
+    Environment  = "production",
+    project_name = "addresses-api"
+  }
 }
 
 module "source_db_endpoint" {
-    source                  = "github.com/LBHackney-IT/aws-dms-terraform.git//dms_endpoint"
-    database_name           = "addresses_api"
-    dms_endpoint_identifier = "source-addresses-postgres"
-    endpoint_type           = "source"
-    engine_name             = "postgres"
-    database_port           = 5500
-    db_server               = data.aws_ssm_parameter.addresses_postgres_hostname.value
-    ssl_mode                = "none"
-    environment_name        = "production"
-    project_name            = "addresses-api"
-    db_username             = data.aws_ssm_parameter.addresses_postgres_username.value
-    db_password             = data.aws_ssm_parameter.addresses_postgres_db_password.value
+  source                  = "github.com/LBHackney-IT/aws-dms-terraform.git//dms_endpoint"
+  database_name           = "addresses_api"
+  dms_endpoint_identifier = "source-addresses-postgres"
+  endpoint_type           = "source"
+  engine_name             = "postgres"
+  database_port           = 5500
+  db_server               = data.aws_ssm_parameter.addresses_postgres_hostname.value
+  ssl_mode                = "none"
+  environment_name        = "production"
+  project_name            = "addresses-api"
+  db_username             = data.aws_ssm_parameter.addresses_postgres_username.value
+  db_password             = data.aws_ssm_parameter.addresses_postgres_db_password.value
 }
 
 module "address-es-dms" {
-    source                       = "github.com/LBHackney-IT/aws-dms-terraform.git//dms_replication_task"
-    environment_name             = "production"
-    project_name                 = "addresses-api"
-    migration_type               = "full-load-and-cdc"
-    replication_instance_arn     = "arn:aws:dms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rep:65CJ5HE2DMCUW5X6EPKTKUDVWA"
-    replication_task_indentifier = "addresses-api-es-dms-task"
-    task_settings                = file("${path.module}/task_settings.json")
-    source_endpoint_arn          = module.source_db_endpoint.dms_endpoint_arn
-    target_endpoint_arn          = aws_dms_endpoint.address_elasticsearch.endpoint_arn
-    task_table_mappings          = file("${path.module}/selection_rules.json")
+  source                       = "github.com/LBHackney-IT/aws-dms-terraform.git//dms_replication_task"
+  environment_name             = "production"
+  project_name                 = "addresses-api"
+  migration_type               = "full-load-and-cdc"
+  replication_instance_arn     = "arn:aws:dms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rep:65CJ5HE2DMCUW5X6EPKTKUDVWA"
+  replication_task_indentifier = "addresses-api-es-dms-task"
+  task_settings                = file("${path.module}/task_settings.json")
+  source_endpoint_arn          = module.source_db_endpoint.dms_endpoint_arn
+  target_endpoint_arn          = aws_dms_endpoint.address_elasticsearch.endpoint_arn
+  task_table_mappings          = file("${path.module}/selection_rules.json")
 }

--- a/terraform/staging/alarms.tf
+++ b/terraform/staging/alarms.tf
@@ -1,0 +1,39 @@
+/*    CLOUDWATCH ALARM SET UP    */
+
+data "aws_sns_topic" "platform_apis" {
+  name = "Platform-APIs-Alerts"
+}
+
+resource "aws_cloudwatch_metric_alarm" "address_api_db_transactions_log_disk_usage" {
+  alarm_name          = "address-api-db-transactions-log-disk-usage-too-high"
+  alarm_description   = "Average database transactions log disk usage higher than threshold in the last 5 minutes"
+  alarm_actions       = ["${data.aws_sns_topic.platform_apis.arn}"]
+  comparison_operator = "GreaterThanThreshold"
+  threshold           = "40000" # Unit: MB
+  evaluation_periods  = "1"
+  metric_name         = "TransactionLogsDiskUsage"
+  namespace           = "RDS"
+  period              = "300"
+  statistic           = "Average"
+
+  dimensions = {
+    DBInstanceIdentifier = "${module.postgres_db_staging.instance_id}"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "address_api_db_free_storage_space" {
+  alarm_name          = "address-api-db-free-storage-space-too-low"
+  alarm_description   = "Average database free storage space log lower than threshold in the last 5 minutes"
+  alarm_actions       = ["${data.aws_sns_topic.platform_apis.arn}"]
+  comparison_operator = "LessThanThreshold"
+  threshold           = "40000" # Unit: MB
+  evaluation_periods  = "1"
+  metric_name         = "FreeStorageSpace"
+  namespace           = "RDS"
+  period              = "300"
+  statistic           = "Average"
+
+  dimensions = {
+    DBInstanceIdentifier = "${module.postgres_db_staging.instance_id}"
+  }
+}

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -80,46 +80,6 @@ module "postgres_db_staging" {
   project_name         = "platform apis"
 }
 
-/*    CLOUDWATCH ALARM SET UP    */
-
-data "aws_sns_topic" "platform_apis" {
-  name = "Platform-APIs-Alerts"
-}
-
-resource "aws_cloudwatch_metric_alarm" "database-transactions-log-disk-usage" {
-  alarm_name          = "database-transactions-log-disk-usage"
-  alarm_description   = "This metric monitors transactions log disk usage goes above a threshold"
-  alarm_actions       = ["${data.aws_sns_topic.platform_apis.arn}"]
-  comparison_operator = "GreaterThanThreshold"
-  threshold           = "3000"
-  evaluation_periods  = "1"
-  metric_name         = "TransactionLogsDiskUsage"
-  namespace           = "RDS"
-  period              = "300"
-  statistic           = "Average"
-
-  dimensions = {
-    DBInstanceIdentifier = "${module.postgres_db_staging.instance_id}"
-  }
-}
-
-resource "aws_cloudwatch_metric_alarm" "free_storage_space_too_low" {
-  alarm_name          = "free-storage-space-too-low"
-  alarm_description   = "Average database free storage space too low within the last 5 minutes"
-  alarm_actions       = ["${data.aws_sns_topic.platform_apis.arn}"]
-  comparison_operator = "LessThanThreshold"
-  threshold           = "40000"
-  evaluation_periods  = "1"
-  metric_name         = "FreeStorageSpace"
-  namespace           = "RDS"
-  period              = "300"
-  statistic           = "Average"
-
-  dimensions = {
-    DBInstanceIdentifier = "${module.postgres_db_staging.instance_id}"
-  }
-}
-
 /*    ELASTICSEARCH SETUP    */
 
 module "elasticsearch_db_staging" {


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/PA-420

## Describe this PR

### *What is the problem we're trying to solve*

We have replication enabled on the Postgres instance in RDS. As a result, the logs that are created for this have the potential for filling up the storage on the RDS instances, which would, in turn, cause the database to stop accepting connections.

### *What changes have we introduced*

Create cloud watch metric alarms to monitor the `Transactional Log disk usage` and `Free storage space MB` metrics.

#### _Checklist_

- [X] Code pipeline builds correctly

### *Follow up actions after merging PR*

Check alarms are created in staging and production