### PR TITLE
Copy over task settings in AWS for the ongoing DMS task

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -190,8 +190,13 @@ module "address-es-dms" {
   migration_type               = "full-load-and-cdc"
   replication_instance_arn     = "arn:aws:dms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rep:65CJ5HE2DMCUW5X6EPKTKUDVWA"
   replication_task_indentifier = "addresses-api-es-dms-task"
-  task_settings                = file("${path.module}/task_settings.json")
-  source_endpoint_arn          = module.source_db_endpoint.dms_endpoint_arn
-  target_endpoint_arn          = aws_dms_endpoint.address_elasticsearch.endpoint_arn
-  task_table_mappings          = file("${path.module}/selection_rules.json")
+  task_settings = templatefile("${path.module}/task_settings.json",
+    {
+      dms_replication_instance_name = "production-dms-instance",
+      dms_instance_task_resource    = "QNHZF2SAHPV4DETSTMAIC2HCRMWU3JN5CJFSB4A"
+    }
+  )
+  source_endpoint_arn = module.source_db_endpoint.dms_endpoint_arn
+  target_endpoint_arn = aws_dms_endpoint.address_elasticsearch.endpoint_arn
+  task_table_mappings = file("${path.module}/selection_rules.json")
 }

--- a/terraform/production/task_settings.json
+++ b/terraform/production/task_settings.json
@@ -1,110 +1,165 @@
 {
   "TargetMetadata": {
-      "TargetSchema": "",
-      "SupportLobs": false,
-      "FullLobMode": false,
-      "LobChunkSize": 0,
-      "LimitedSizeLobMode": false,
-      "LobMaxSize": 0,
-      "InlineLobMaxSize": 0,
-      "LoadMaxFileSize": 0,
-      "ParallelLoadThreads": 5,
-      "ParallelLoadBufferSize": 1000,
-      "BatchApplyEnabled": false,
-      "TaskRecoveryTableEnabled": false,
-      "ParallelLoadQueuesPerThread": 0,
-      "ParallelApplyThreads": 0,
-      "ParallelApplyBufferSize": 0,
-      "ParallelApplyQueuesPerThread": 0
+    "TargetSchema": "",
+    "SupportLobs": false,
+    "FullLobMode": false,
+    "LobChunkSize": 0,
+    "LimitedSizeLobMode": false,
+    "LobMaxSize": 0,
+    "InlineLobMaxSize": 0,
+    "LoadMaxFileSize": 0,
+    "ParallelLoadThreads": 5,
+    "ParallelLoadBufferSize": 1000,
+    "BatchApplyEnabled": false,
+    "TaskRecoveryTableEnabled": false,
+    "ParallelLoadQueuesPerThread": 0,
+    "ParallelApplyThreads": 0,
+    "ParallelApplyBufferSize": 0,
+    "ParallelApplyQueuesPerThread": 0
   },
   "FullLoadSettings": {
-      "TargetTablePrepMode": "DROP_AND_CREATE",
-      "CreatePkAfterFullLoad": false,
-      "StopTaskCachedChangesApplied": false,
-      "StopTaskCachedChangesNotApplied": false,
-      "MaxFullLoadSubTasks": 8,
-      "TransactionConsistencyTimeout": 600,
-      "CommitRate": 10000
+    "TargetTablePrepMode": "DROP_AND_CREATE",
+    "CreatePkAfterFullLoad": false,
+    "StopTaskCachedChangesApplied": false,
+    "StopTaskCachedChangesNotApplied": false,
+    "MaxFullLoadSubTasks": 8,
+    "TransactionConsistencyTimeout": 600,
+    "CommitRate": 10000
   },
   "Logging": {
-      "EnableLogging": true,
-      "LogComponents": [
-          {
-              "Id": "SOURCE_UNLOAD",
-              "Severity": "LOGGER_SEVERITY_DEFAULT"
-          },
-          {
-              "Id": "SOURCE_CAPTURE",
-              "Severity": "LOGGER_SEVERITY_DEFAULT"
-          },
-          {
-              "Id": "TARGET_LOAD",
-              "Severity": "LOGGER_SEVERITY_DEFAULT"
-          },
-          {
-              "Id": "TARGET_APPLY",
-              "Severity": "LOGGER_SEVERITY_DEFAULT"
-          },
-          {
-              "Id": "TASK_MANAGER",
-              "Severity": "LOGGER_SEVERITY_DEFAULT"
-          }
-      ],
-      "CloudWatchLogGroup": null,
-      "CloudWatchLogStream": null
+    "EnableLogging": true,
+    "LogComponents": [{
+        "Id": "TRANSFORMATION",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "SOURCE_UNLOAD",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "IO",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "TARGET_LOAD",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "PERFORMANCE",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "SOURCE_CAPTURE",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "SORTER",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "REST_SERVER",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "VALIDATOR_EXT",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "TARGET_APPLY",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "TASK_MANAGER",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "TABLES_MANAGER",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "METADATA_MANAGER",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "FILE_FACTORY",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "COMMON",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "ADDONS",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "DATA_STRUCTURE",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "COMMUNICATION",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "FILE_TRANSFER",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      }
+    ],
+    "CloudWatchLogGroup": "dms-tasks-${dms_replication_instance_name}",
+    "CloudWatchLogStream": "dms-task-${dms_instance_task_resource}"
   },
   "ControlTablesSettings": {
-      "historyTimeslotInMinutes": 5,
-      "ControlSchema": "",
-      "HistoryTimeslotInMinutes": 5,
-      "HistoryTableEnabled": false,
-      "SuspendedTablesTableEnabled": false,
-      "StatusTableEnabled": false
+    "historyTimeslotInMinutes": 5,
+    "ControlSchema": "",
+    "HistoryTimeslotInMinutes": 5,
+    "HistoryTableEnabled": false,
+    "SuspendedTablesTableEnabled": false,
+    "StatusTableEnabled": false
   },
   "StreamBufferSettings": {
-      "StreamBufferCount": 3,
-      "StreamBufferSizeInMB": 8,
-      "CtrlStreamBufferSizeInMB": 5
+    "StreamBufferCount": 3,
+    "StreamBufferSizeInMB": 8,
+    "CtrlStreamBufferSizeInMB": 5
   },
   "ChangeProcessingDdlHandlingPolicy": {
-      "HandleSourceTableDropped": true,
-      "HandleSourceTableTruncated": true,
-      "HandleSourceTableAltered": true
+    "HandleSourceTableDropped": true,
+    "HandleSourceTableTruncated": true,
+    "HandleSourceTableAltered": true
   },
   "ErrorBehavior": {
-      "DataErrorPolicy": "LOG_ERROR",
-      "DataTruncationErrorPolicy": "LOG_ERROR",
-      "DataErrorEscalationPolicy": "SUSPEND_TABLE",
-      "DataErrorEscalationCount": 0,
-      "TableErrorPolicy": "SUSPEND_TABLE",
-      "TableErrorEscalationPolicy": "STOP_TASK",
-      "TableErrorEscalationCount": 0,
-      "RecoverableErrorCount": -1,
-      "RecoverableErrorInterval": 5,
-      "RecoverableErrorThrottling": true,
-      "RecoverableErrorThrottlingMax": 1800,
-      "RecoverableErrorStopRetryAfterThrottlingMax": false,
-      "ApplyErrorDeletePolicy": "IGNORE_RECORD",
-      "ApplyErrorInsertPolicy": "LOG_ERROR",
-      "ApplyErrorUpdatePolicy": "LOG_ERROR",
-      "ApplyErrorEscalationPolicy": "LOG_ERROR",
-      "ApplyErrorEscalationCount": 0,
-      "ApplyErrorFailOnTruncationDdl": false,
-      "FullLoadIgnoreConflicts": true,
-      "FailOnTransactionConsistencyBreached": false,
-      "FailOnNoTablesCaptured": false
+    "DataErrorPolicy": "LOG_ERROR",
+    "DataTruncationErrorPolicy": "LOG_ERROR",
+    "DataErrorEscalationPolicy": "SUSPEND_TABLE",
+    "DataErrorEscalationCount": 0,
+    "TableErrorPolicy": "SUSPEND_TABLE",
+    "TableErrorEscalationPolicy": "STOP_TASK",
+    "TableErrorEscalationCount": 0,
+    "RecoverableErrorCount": -1,
+    "RecoverableErrorInterval": 5,
+    "RecoverableErrorThrottling": true,
+    "RecoverableErrorThrottlingMax": 1800,
+    "RecoverableErrorStopRetryAfterThrottlingMax": false,
+    "ApplyErrorDeletePolicy": "IGNORE_RECORD",
+    "ApplyErrorInsertPolicy": "LOG_ERROR",
+    "ApplyErrorUpdatePolicy": "LOG_ERROR",
+    "ApplyErrorEscalationPolicy": "LOG_ERROR",
+    "ApplyErrorEscalationCount": 0,
+    "ApplyErrorFailOnTruncationDdl": false,
+    "FullLoadIgnoreConflicts": true,
+    "FailOnTransactionConsistencyBreached": false,
+    "FailOnNoTablesCaptured": false
   },
   "ChangeProcessingTuning": {
-      "BatchApplyPreserveTransaction": true,
-      "BatchApplyTimeoutMin": 1,
-      "BatchApplyTimeoutMax": 30,
-      "BatchApplyMemoryLimit": 500,
-      "BatchSplitSize": 0,
-      "MinTransactionSize": 1000,
-      "CommitTimeout": 1,
-      "MemoryLimitTotal": 1024,
-      "MemoryKeepTime": 60,
-      "StatementCacheSize": 50
+    "BatchApplyPreserveTransaction": true,
+    "BatchApplyTimeoutMin": 1,
+    "BatchApplyTimeoutMax": 30,
+    "BatchApplyMemoryLimit": 500,
+    "BatchSplitSize": 0,
+    "MinTransactionSize": 1000,
+    "CommitTimeout": 1,
+    "MemoryLimitTotal": 1024,
+    "MemoryKeepTime": 60,
+    "StatementCacheSize": 50
   },
   "PostProcessingRules": null,
   "CharacterSetSettings": null,

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -191,8 +191,13 @@ module "address-es-dms" {
   migration_type               = "full-load-and-cdc"
   replication_instance_arn     = "arn:aws:dms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rep:DNTOW6TGQEGCAOWQMZYHQRTWAA"
   replication_task_indentifier = "addresses-api-es-dms-task"
-  task_settings                = file("${path.module}/task_settings.json")
-  source_endpoint_arn          = module.source_db_endpoint.dms_endpoint_arn
-  target_endpoint_arn          = aws_dms_endpoint.address_elasticsearch.endpoint_arn
-  task_table_mappings          = file("${path.module}/selection_rules.json")
+  task_settings = templatefile("${path.module}/task_settings.json",
+    {
+      dms_replication_instance_name = "staging-dms-instance",
+      dms_instance_task_resource    = "2374SA74Z4BGD3UW4DZNUD5H2C43W4CXXQC56ZI"
+    }
+  )
+  source_endpoint_arn = module.source_db_endpoint.dms_endpoint_arn
+  target_endpoint_arn = aws_dms_endpoint.address_elasticsearch.endpoint_arn
+  task_table_mappings = file("${path.module}/selection_rules.json")
 }

--- a/terraform/staging/task_settings.json
+++ b/terraform/staging/task_settings.json
@@ -1,166 +1,165 @@
 {
   "TargetMetadata": {
-      "TargetSchema": "",
-      "SupportLobs": false,
-      "FullLobMode": false,
-      "LobChunkSize": 0,
-      "LimitedSizeLobMode": false,
-      "LobMaxSize": 0,
-      "InlineLobMaxSize": 0,
-      "LoadMaxFileSize": 0,
-      "ParallelLoadThreads": 5,
-      "ParallelLoadBufferSize": 1000,
-      "BatchApplyEnabled": false,
-      "TaskRecoveryTableEnabled": false,
-      "ParallelLoadQueuesPerThread": 0,
-      "ParallelApplyThreads": 0,
-      "ParallelApplyBufferSize": 0,
-      "ParallelApplyQueuesPerThread": 0
+    "TargetSchema": "",
+    "SupportLobs": false,
+    "FullLobMode": false,
+    "LobChunkSize": 0,
+    "LimitedSizeLobMode": false,
+    "LobMaxSize": 0,
+    "InlineLobMaxSize": 0,
+    "LoadMaxFileSize": 0,
+    "ParallelLoadThreads": 5,
+    "ParallelLoadBufferSize": 1000,
+    "BatchApplyEnabled": false,
+    "TaskRecoveryTableEnabled": false,
+    "ParallelLoadQueuesPerThread": 0,
+    "ParallelApplyThreads": 0,
+    "ParallelApplyBufferSize": 0,
+    "ParallelApplyQueuesPerThread": 0
   },
   "FullLoadSettings": {
-      "TargetTablePrepMode": "DROP_AND_CREATE",
-      "CreatePkAfterFullLoad": false,
-      "StopTaskCachedChangesApplied": false,
-      "StopTaskCachedChangesNotApplied": false,
-      "MaxFullLoadSubTasks": 8,
-      "TransactionConsistencyTimeout": 600,
-      "CommitRate": 10000
+    "TargetTablePrepMode": "DROP_AND_CREATE",
+    "CreatePkAfterFullLoad": false,
+    "StopTaskCachedChangesApplied": false,
+    "StopTaskCachedChangesNotApplied": false,
+    "MaxFullLoadSubTasks": 8,
+    "TransactionConsistencyTimeout": 600,
+    "CommitRate": 10000
   },
   "Logging": {
-      "EnableLogging": true,
-      "LogComponents": [
-          {
-              "Id": "TRANSFORMATION",
-              "Severity": "LOGGER_SEVERITY_DEFAULT"
-          },
-          {
-              "Id": "SOURCE_UNLOAD",
-              "Severity": "LOGGER_SEVERITY_DEFAULT"
-          },
-          {
-              "Id": "IO",
-              "Severity": "LOGGER_SEVERITY_DEFAULT"
-          },
-          {
-              "Id": "TARGET_LOAD",
-              "Severity": "LOGGER_SEVERITY_DEFAULT"
-          },
-          {
-              "Id": "PERFORMANCE",
-              "Severity": "LOGGER_SEVERITY_DEFAULT"
-          },
-          {
-              "Id": "SOURCE_CAPTURE",
-              "Severity": "LOGGER_SEVERITY_DEFAULT"
-          },
-          {
-              "Id": "SORTER",
-              "Severity": "LOGGER_SEVERITY_DEFAULT"
-          },
-          {
-              "Id": "REST_SERVER",
-              "Severity": "LOGGER_SEVERITY_DEFAULT"
-          },
-          {
-              "Id": "VALIDATOR_EXT",
-              "Severity": "LOGGER_SEVERITY_DEFAULT"
-          },
-          {
-              "Id": "TARGET_APPLY",
-              "Severity": "LOGGER_SEVERITY_DEFAULT"
-          },
-          {
-              "Id": "TASK_MANAGER",
-              "Severity": "LOGGER_SEVERITY_DEFAULT"
-          },
-          {
-              "Id": "TABLES_MANAGER",
-              "Severity": "LOGGER_SEVERITY_DEFAULT"
-          },
-          {
-              "Id": "METADATA_MANAGER",
-              "Severity": "LOGGER_SEVERITY_DEFAULT"
-          },
-          {
-              "Id": "FILE_FACTORY",
-              "Severity": "LOGGER_SEVERITY_DEFAULT"
-          },
-          {
-              "Id": "COMMON",
-              "Severity": "LOGGER_SEVERITY_DEFAULT"
-          },
-          {
-              "Id": "ADDONS",
-              "Severity": "LOGGER_SEVERITY_DEFAULT"
-          },
-          {
-              "Id": "DATA_STRUCTURE",
-              "Severity": "LOGGER_SEVERITY_DEFAULT"
-          },
-          {
-              "Id": "COMMUNICATION",
-              "Severity": "LOGGER_SEVERITY_DEFAULT"
-          },
-          {
-              "Id": "FILE_TRANSFER",
-              "Severity": "LOGGER_SEVERITY_DEFAULT"
-          }
-      ],
-      "CloudWatchLogGroup": "dms-tasks-staging-dms-instance",
-      "CloudWatchLogStream": "dms-task-2374SA74Z4BGD3UW4DZNUD5H2C43W4CXXQC56ZI"
+    "EnableLogging": true,
+    "LogComponents": [{
+        "Id": "TRANSFORMATION",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "SOURCE_UNLOAD",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "IO",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "TARGET_LOAD",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "PERFORMANCE",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "SOURCE_CAPTURE",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "SORTER",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "REST_SERVER",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "VALIDATOR_EXT",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "TARGET_APPLY",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "TASK_MANAGER",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "TABLES_MANAGER",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "METADATA_MANAGER",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "FILE_FACTORY",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "COMMON",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "ADDONS",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "DATA_STRUCTURE",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "COMMUNICATION",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      },
+      {
+        "Id": "FILE_TRANSFER",
+        "Severity": "LOGGER_SEVERITY_DEFAULT"
+      }
+    ],
+    "CloudWatchLogGroup": "dms-tasks-${dms_replication_instance_name}",
+    "CloudWatchLogStream": "dms-task-${dms_instance_task_resource}"
   },
   "ControlTablesSettings": {
-      "historyTimeslotInMinutes": 5,
-      "ControlSchema": "",
-      "HistoryTimeslotInMinutes": 5,
-      "HistoryTableEnabled": false,
-      "SuspendedTablesTableEnabled": false,
-      "StatusTableEnabled": false
+    "historyTimeslotInMinutes": 5,
+    "ControlSchema": "",
+    "HistoryTimeslotInMinutes": 5,
+    "HistoryTableEnabled": false,
+    "SuspendedTablesTableEnabled": false,
+    "StatusTableEnabled": false
   },
   "StreamBufferSettings": {
-      "StreamBufferCount": 3,
-      "StreamBufferSizeInMB": 8,
-      "CtrlStreamBufferSizeInMB": 5
+    "StreamBufferCount": 3,
+    "StreamBufferSizeInMB": 8,
+    "CtrlStreamBufferSizeInMB": 5
   },
   "ChangeProcessingDdlHandlingPolicy": {
-      "HandleSourceTableDropped": true,
-      "HandleSourceTableTruncated": true,
-      "HandleSourceTableAltered": true
+    "HandleSourceTableDropped": true,
+    "HandleSourceTableTruncated": true,
+    "HandleSourceTableAltered": true
   },
   "ErrorBehavior": {
-      "DataErrorPolicy": "LOG_ERROR",
-      "DataTruncationErrorPolicy": "LOG_ERROR",
-      "DataErrorEscalationPolicy": "SUSPEND_TABLE",
-      "DataErrorEscalationCount": 0,
-      "TableErrorPolicy": "SUSPEND_TABLE",
-      "TableErrorEscalationPolicy": "STOP_TASK",
-      "TableErrorEscalationCount": 0,
-      "RecoverableErrorCount": -1,
-      "RecoverableErrorInterval": 5,
-      "RecoverableErrorThrottling": true,
-      "RecoverableErrorThrottlingMax": 1800,
-      "RecoverableErrorStopRetryAfterThrottlingMax": false,
-      "ApplyErrorDeletePolicy": "IGNORE_RECORD",
-      "ApplyErrorInsertPolicy": "LOG_ERROR",
-      "ApplyErrorUpdatePolicy": "LOG_ERROR",
-      "ApplyErrorEscalationPolicy": "LOG_ERROR",
-      "ApplyErrorEscalationCount": 0,
-      "ApplyErrorFailOnTruncationDdl": false,
-      "FullLoadIgnoreConflicts": true,
-      "FailOnTransactionConsistencyBreached": false,
-      "FailOnNoTablesCaptured": false
+    "DataErrorPolicy": "LOG_ERROR",
+    "DataTruncationErrorPolicy": "LOG_ERROR",
+    "DataErrorEscalationPolicy": "SUSPEND_TABLE",
+    "DataErrorEscalationCount": 0,
+    "TableErrorPolicy": "SUSPEND_TABLE",
+    "TableErrorEscalationPolicy": "STOP_TASK",
+    "TableErrorEscalationCount": 0,
+    "RecoverableErrorCount": -1,
+    "RecoverableErrorInterval": 5,
+    "RecoverableErrorThrottling": true,
+    "RecoverableErrorThrottlingMax": 1800,
+    "RecoverableErrorStopRetryAfterThrottlingMax": false,
+    "ApplyErrorDeletePolicy": "IGNORE_RECORD",
+    "ApplyErrorInsertPolicy": "LOG_ERROR",
+    "ApplyErrorUpdatePolicy": "LOG_ERROR",
+    "ApplyErrorEscalationPolicy": "LOG_ERROR",
+    "ApplyErrorEscalationCount": 0,
+    "ApplyErrorFailOnTruncationDdl": false,
+    "FullLoadIgnoreConflicts": true,
+    "FailOnTransactionConsistencyBreached": false,
+    "FailOnNoTablesCaptured": false
   },
   "ChangeProcessingTuning": {
-      "BatchApplyPreserveTransaction": true,
-      "BatchApplyTimeoutMin": 1,
-      "BatchApplyTimeoutMax": 30,
-      "BatchApplyMemoryLimit": 500,
-      "BatchSplitSize": 0,
-      "MinTransactionSize": 1000,
-      "CommitTimeout": 1,
-      "MemoryLimitTotal": 1024,
-      "MemoryKeepTime": 60,
-      "StatementCacheSize": 50
+    "BatchApplyPreserveTransaction": true,
+    "BatchApplyTimeoutMin": 1,
+    "BatchApplyTimeoutMax": 30,
+    "BatchApplyMemoryLimit": 500,
+    "BatchSplitSize": 0,
+    "MinTransactionSize": 1000,
+    "CommitTimeout": 1,
+    "MemoryLimitTotal": 1024,
+    "MemoryKeepTime": 60,
+    "StatementCacheSize": 50
   },
   "PostProcessingRules": null,
   "CharacterSetSettings": null,

--- a/terraform/staging/task_settings.json
+++ b/terraform/staging/task_settings.json
@@ -30,7 +30,23 @@
       "EnableLogging": true,
       "LogComponents": [
           {
+              "Id": "TRANSFORMATION",
+              "Severity": "LOGGER_SEVERITY_DEFAULT"
+          },
+          {
               "Id": "SOURCE_UNLOAD",
+              "Severity": "LOGGER_SEVERITY_DEFAULT"
+          },
+          {
+              "Id": "IO",
+              "Severity": "LOGGER_SEVERITY_DEFAULT"
+          },
+          {
+              "Id": "TARGET_LOAD",
+              "Severity": "LOGGER_SEVERITY_DEFAULT"
+          },
+          {
+              "Id": "PERFORMANCE",
               "Severity": "LOGGER_SEVERITY_DEFAULT"
           },
           {
@@ -38,7 +54,15 @@
               "Severity": "LOGGER_SEVERITY_DEFAULT"
           },
           {
-              "Id": "TARGET_LOAD",
+              "Id": "SORTER",
+              "Severity": "LOGGER_SEVERITY_DEFAULT"
+          },
+          {
+              "Id": "REST_SERVER",
+              "Severity": "LOGGER_SEVERITY_DEFAULT"
+          },
+          {
+              "Id": "VALIDATOR_EXT",
               "Severity": "LOGGER_SEVERITY_DEFAULT"
           },
           {
@@ -48,10 +72,42 @@
           {
               "Id": "TASK_MANAGER",
               "Severity": "LOGGER_SEVERITY_DEFAULT"
+          },
+          {
+              "Id": "TABLES_MANAGER",
+              "Severity": "LOGGER_SEVERITY_DEFAULT"
+          },
+          {
+              "Id": "METADATA_MANAGER",
+              "Severity": "LOGGER_SEVERITY_DEFAULT"
+          },
+          {
+              "Id": "FILE_FACTORY",
+              "Severity": "LOGGER_SEVERITY_DEFAULT"
+          },
+          {
+              "Id": "COMMON",
+              "Severity": "LOGGER_SEVERITY_DEFAULT"
+          },
+          {
+              "Id": "ADDONS",
+              "Severity": "LOGGER_SEVERITY_DEFAULT"
+          },
+          {
+              "Id": "DATA_STRUCTURE",
+              "Severity": "LOGGER_SEVERITY_DEFAULT"
+          },
+          {
+              "Id": "COMMUNICATION",
+              "Severity": "LOGGER_SEVERITY_DEFAULT"
+          },
+          {
+              "Id": "FILE_TRANSFER",
+              "Severity": "LOGGER_SEVERITY_DEFAULT"
           }
       ],
-      "CloudWatchLogGroup": null,
-      "CloudWatchLogStream": null
+      "CloudWatchLogGroup": "dms-tasks-staging-dms-instance",
+      "CloudWatchLogStream": "dms-task-2374SA74Z4BGD3UW4DZNUD5H2C43W4CXXQC56ZI"
   },
   "ControlTablesSettings": {
       "historyTimeslotInMinutes": 5,


### PR DESCRIPTION
It looks like AWS generates extra task settings for the DMS task.
As a result, when terraform, compares the `task settings.json` with the task settings in AWS, it would plan an update-in-place/modification on the existing task.

This commit copies over the task settings as they are in the AWS console so that terraform doesn't detect any changes and therefore  trigger no modifications.

Have tested this locally with `terraform plan`

- [X] Code pipeline builds correctly

### *Follow up actions after merging PR*

Check this works in production.