### PR TITLE
Modifies since includes start date

### DIFF
--- a/AddressesAPI.Tests/V2/Gateways/SearchAddressesGatewayTest.cs
+++ b/AddressesAPI.Tests/V2/Gateways/SearchAddressesGatewayTest.cs
@@ -508,6 +508,32 @@ namespace AddressesAPI.Tests.V2.Gateways
             addressKeys.Should().Contain(savedAddresses.ElementAt(2).AddressKey);
             addressKeys.Should().Contain(savedAddresses.ElementAt(3).AddressKey);
         }
+
+        [Test]
+        public async Task WillOnlyReturnAddressesModifiedSinceADateIfTheyAreNewlyCreated()
+        {
+            var savedAddresses = new List<QueryableAddress>
+            {
+                new QueryableAddress {PropertyChangeDate = 20200523, PropertyStartDate = 20190523},
+                new QueryableAddress {PropertyChangeDate = 20191204, PropertyStartDate = 20190523},
+                new QueryableAddress {PropertyStartDate = 20200801, PropertyChangeDate = null},
+                new QueryableAddress {PropertyStartDate = 20201203, PropertyChangeDate = null}
+            };
+            savedAddresses = await IndexAddresses(savedAddresses).ConfigureAwait(true);
+
+            var request = new SearchParameters
+            {
+                Page = 1,
+                PageSize = 50,
+                Gazetteer = GlobalConstants.Gazetteer.Both,
+                ModifiedSince = new DateTime(2020, 06, 01),
+            };
+            var (addressKeys, _) = await _classUnderTest.SearchAddresses(request).ConfigureAwait(true);
+
+            addressKeys.Count.Should().Be(2);
+            addressKeys.Should().Contain(savedAddresses.ElementAt(2).AddressKey);
+            addressKeys.Should().Contain(savedAddresses.ElementAt(3).AddressKey);
+        }
         #endregion
 
         #region parentShells

--- a/AddressesAPI.Tests/V2/Helper/TestDataHelper.cs
+++ b/AddressesAPI.Tests/V2/Helper/TestDataHelper.cs
@@ -51,6 +51,7 @@ namespace AddressesAPI.Tests.V2.Helper
                 BuildingNumber = address.BuildingNumber,
                 PropertyShell = address.PropertyShell,
                 PropertyChangeDate = address.PropertyChangeDate,
+                PropertyStartDate = address.PropertyStartDate,
                 UsageCode = address.UsageCode,
                 UsagePrimary = address.UsagePrimary,
                 AddressChangeDate = address.AddressChangeDate,
@@ -102,16 +103,16 @@ namespace AddressesAPI.Tests.V2.Helper
             if (request?.PaonStartNumber == 0) randomAddressRecord.PaonStartNumber = null;
             if (request?.PropertyChangeDate != null) randomAddressRecord.PropertyChangeDate = request.PropertyChangeDate;
             if (request?.PropertyChangeDate == 0) randomAddressRecord.PropertyChangeDate = null;
+            if (request?.PropertyStartDate != null) randomAddressRecord.PropertyStartDate = request.PropertyStartDate;
             if (request?.BuildingNumber != null)
                 randomAddressRecord.BuildingNumber = ReplaceEmptyStringWithNull(request.BuildingNumber);
-            if (request?.UnitNumber != null) randomAddressRecord.UnitNumber = request.UnitNumber;
-            if (request?.UnitNumber == 0) randomAddressRecord.UnitNumber = null;
             if (request?.UnitName != null) randomAddressRecord.UnitName = ReplaceEmptyStringWithNull(request.UnitName);
             if (request?.Line1 != null) randomAddressRecord.Line1 = request.Line1;
             if (request?.Line2 != null) randomAddressRecord.Line2 = request.Line2;
             if (request?.Line3 != null) randomAddressRecord.Line3 = request.Line3;
             if (request?.Line4 != null) randomAddressRecord.Line4 = request.Line4;
             randomAddressRecord.ParentUPRN = (request?.ParentUPRN).GetValueOrDefault() == 0 ? null : request.ParentUPRN;
+            randomAddressRecord.UnitNumber = (request?.UnitNumber).GetValueOrDefault() == 0 ? null : request.UnitNumber;
             randomAddressRecord.PropertyShell = request?.PropertyShell ?? false;
             return randomAddressRecord;
         }

--- a/AddressesAPI/Infrastructure/QueryableAddress.cs
+++ b/AddressesAPI/Infrastructure/QueryableAddress.cs
@@ -85,5 +85,8 @@ namespace AddressesAPI.Infrastructure
 
         [Text(Name = "blpu_last_update_date")]
         public int? PropertyChangeDate { get; set; }
+
+        [Text(Name = "blpu_start_date")]
+        public int PropertyStartDate { get; set; }
     }
 }

--- a/AddressesAPI/V2/Gateways/ElasticGateway.cs
+++ b/AddressesAPI/V2/Gateways/ElasticGateway.cs
@@ -180,9 +180,10 @@ namespace AddressesAPI.V2.Gateways
 
             var date = Convert.ToInt32(request.ModifiedSince.Value.ToString("yyyyMMdd"));
             return q.Range(r => r.Field(f => f.PropertyChangeDate)
-                .GreaterThanOrEquals(date));
+                       .GreaterThanOrEquals(date))
+                   || q.Range(r => r.Field(f => f.PropertyStartDate)
+                       .GreaterThanOrEquals(date));
         }
-
 
         private static QueryContainer HasAParentShell(QueryContainerDescriptor<QueryableAddress> q)
         {

--- a/data/elasticsearch/index.json
+++ b/data/elasticsearch/index.json
@@ -206,6 +206,9 @@
       },
       "blpu_last_update_date": {
         "type": "integer"
+      },
+      "blpu_start_date": {
+        "type": "integer"
       }
     }
   }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/PA-405
## Describe this PR

### *What is the problem we're trying to solve*

If an address has been recently created then it won't have a modified since date. However, it should still be returned if the start date is after the modified since date.

### *What changes have we introduced*

When filtering addresses that have been modified since a date, check if either the start date or modified since date are after this date.

#### _Checklist_

- [x] Added tests to cover all new production code
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly
