### PR TITLE
correct elasticsearch security group for lambda

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -136,7 +136,7 @@ custom:
     production:
       securityGroupIds:
         - sg-0559e24a4d1ee0ddc
-        - sg-0942a8227a2ecc6f8
+        - sg-0d6c0357cc2febe32
       subnetIds:
         - subnet-01d3657f97a243261
         - subnet-0b7b8fea07efabf34


### PR DESCRIPTION
The security group that allows the API lambda to talk to the elasticsearch cluster was wrong. 