### PR TITLE
If the ordering of words is correct in an address it should be ranked higher

### DIFF
--- a/AddressesAPI.Tests/V2/Gateways/SearchAddressesGatewayTest.cs
+++ b/AddressesAPI.Tests/V2/Gateways/SearchAddressesGatewayTest.cs
@@ -797,8 +797,10 @@ namespace AddressesAPI.Tests.V2.Gateways
             addresses.ElementAt(1).Should().BeEquivalentTo(savedAddresses.ElementAt(0).AddressKey);
         }
 
-        [Test]
-        public async Task ItWillOrderMatchesInTheCorrectOrderOverMatchesWillSearchTermsSpreadOut()
+        [TestCase("eton road")]
+        [TestCase("12 eton road london")]
+        [TestCase("12 eton road")]
+        public async Task ItWillOrderMatchesInTheCorrectOrderOverMatchesWillSearchTermsSpreadOut(string query)
         {
             var savedAddresses = new List<QueryableAddress>
             {
@@ -838,7 +840,7 @@ namespace AddressesAPI.Tests.V2.Gateways
                 Page = 1,
                 PageSize = 50,
                 Gazetteer = GlobalConstants.Gazetteer.Both,
-                AddressQuery = "12 eton road"
+                AddressQuery = query
             };
             var (addresses, _) = await _classUnderTest.SearchAddresses(request).ConfigureAwait(true);
 

--- a/AddressesAPI.Tests/V2/Gateways/SearchAddressesGatewayTest.cs
+++ b/AddressesAPI.Tests/V2/Gateways/SearchAddressesGatewayTest.cs
@@ -850,6 +850,47 @@ namespace AddressesAPI.Tests.V2.Gateways
         }
 
         [Test]
+        public async Task WontOrderMatchedWithMultipleFuzzyTermsHigherThenThoseWithOneTerm()
+        {
+            var savedAddresses = new List<QueryableAddress>
+            {
+                new QueryableAddress
+                {
+                    Street = "MARE STREET",
+                    Town = "LONDON",
+                    Postcode = "E8 3QE",
+                    Line1 = "MINI MART",
+                    Line2 = " 185-187 MARE STREET",
+                    Line3 = " HACKNEY",
+                    Line4 = " LONDON"
+                },
+                new QueryableAddress
+                {
+                    Street = "MARE STREET",
+                    Town = "LONDON",
+                    Postcode = "E8 1DU",
+                    Line1 = "ST JOHNS GARDENS",
+                    Line2 = " MARE STREET",
+                    Line3 = " HACKNEY",
+                    Line4 = " LONDON"
+                }
+            };
+            savedAddresses = await IndexAddresses(savedAddresses).ConfigureAwait(true);
+
+            var request = new SearchParameters
+            {
+                Page = 1,
+                PageSize = 50,
+                Gazetteer = GlobalConstants.Gazetteer.Both,
+                AddressQuery = "mare street"
+            };
+            var (addresses, _) = await _classUnderTest.SearchAddresses(request).ConfigureAwait(true);
+
+            addresses.Count.Should().Be(2);
+            addresses.ElementAt(0).Should().BeEquivalentTo(savedAddresses.ElementAt(1).AddressKey);
+            addresses.ElementAt(1).Should().BeEquivalentTo(savedAddresses.ElementAt(0).AddressKey);
+        }
+        [Test]
         public async Task WillFirstlyOrderByTown()
         {
             var savedAddresses = new List<QueryableAddress>

--- a/AddressesAPI/V2/Gateways/ElasticGateway.cs
+++ b/AddressesAPI/V2/Gateways/ElasticGateway.cs
@@ -122,6 +122,8 @@ namespace AddressesAPI.V2.Gateways
         {
             if (request.AddressQuery == null) return null;
 
+            // This query will return addresses which have all of the search terms somewhere in the addresses, with a degree
+            // of fuzziness and using allowed synonyms.
             var fuzzyMatchText = q.Match(c => c
                 .Field(f => f.FullAddress)
                 .Query(request.AddressQuery)
@@ -129,24 +131,39 @@ namespace AddressesAPI.V2.Gateways
                 .Fuzziness(Fuzziness.Auto)
                 .Operator(Operator.And)
             );
+            // This will ensure that numbers are matched exactly.
             var exactlyMatchNumbers = q.Match(m => m
                 .Field("full_address.extracted_numbers")
                 .ZeroTermsQuery(ZeroTermsQuery.All)
                 .Analyzer("extract_number_analyzer")
                 .Query(request.AddressQuery)
             );
-
+            // This will boost the score of addresses which have exact matches of all search terms (i.e. no synonyms or fuzziness).
             var exactMatch = q.Match(m => m
                 .Field("full_address.exact_text")
                 .Analyzer("standard")
                 .Query(request.AddressQuery)
                 .Operator(Operator.And));
-            var orderedMatch = q.Match(m => m
-                .Field("full_address.keyword")
-                .Analyzer("whitespace_removed")
+            // This will boost the score for addresses which have the exact search string, in the correct order, in one of the address lines.
+            var orderedMatch = q.MatchPhrase(m => m
+                .Field("full_address.exact_text")
+                .Analyzer("standard")
+                .Query(request.AddressQuery));
+            // This will boost the score for addresses which for which one of the address lines appears in full and in the correct order
+            // in the search string.
+            var matchFullLines = q.MultiMatch(m => m
+                .Fields(c => c
+                    .Field(f => f.Line1)
+                    .Field(f => f.Line2)
+                    .Field(f => f.Line3)
+                    .Field(f => f.Line4)
+                )
+                .Analyzer("standard")
+                .TieBreaker(0.0)
+                .ZeroTermsQuery(ZeroTermsQuery.All)
                 .Query(request.AddressQuery));
 
-            return (fuzzyMatchText && exactlyMatchNumbers) || (exactMatch) || orderedMatch;
+            return (fuzzyMatchText && exactlyMatchNumbers && matchFullLines) || (orderedMatch) || (exactMatch);
         }
 
         private static SortDescriptor<QueryableAddress> SortResults(SortDescriptor<QueryableAddress> srt)

--- a/AddressesAPI/V2/Gateways/ElasticGateway.cs
+++ b/AddressesAPI/V2/Gateways/ElasticGateway.cs
@@ -129,6 +129,7 @@ namespace AddressesAPI.V2.Gateways
                 .Query(request.AddressQuery)
                 .Analyzer("address_text")
                 .Fuzziness(Fuzziness.Auto)
+                .Boost(0)
                 .Operator(Operator.And)
             );
             // This will ensure that numbers are matched exactly.

--- a/data/elasticsearch/index.json
+++ b/data/elasticsearch/index.json
@@ -110,22 +110,26 @@
       },
       "line1" : {
         "type" : "text",
-        "analyzer": "address_text",
-        "copy_to": "full_address"
+        "analyzer": "standard",
+        "copy_to": "full_address",
+        "similarity": "boolean"
       },
       "line2" : {
         "type" : "text",
-        "analyzer": "address_text",
+        "analyzer": "standard",
+        "similarity": "boolean",
         "copy_to": "full_address"
       },
       "line3" : {
         "type" : "text",
-        "analyzer": "address_text",
-        "copy_to": "full_address"
+        "analyzer": "standard",
+        "copy_to": "full_address",
+        "similarity": "boolean"
       },
       "line4" : {
         "type" : "text",
-        "analyzer": "address_text",
+        "analyzer": "standard",
+        "similarity": "boolean",
         "copy_to": "full_address"
       },
       "full_address" : {
@@ -142,10 +146,6 @@
             "type" : "text",
             "analyzer": "standard",
             "similarity": "boolean"
-          },
-          "keyword": {
-            "type" : "text",
-            "analyzer" : "whitespace_removed"
           }
         }
       },


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/PA-412
## Describe this PR

### *What is the problem we're trying to solve*

Addresses which match the search term and are ordered correctly should be ranked higher than those with words in a different order.

### *What changes have we introduced*

Added some queries which check against a full phrase either in different addresses lines or across all address lines to boost the score. 

#### _Checklist_

- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

More testing in staging 😁 
