### PR TITLE
Schedule reindexing lambda

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -37,6 +37,19 @@ functions:
     environment:
       SQS_QUEUE_URL: ${ssm:/addresses-api/${self:provider.stage}/reindexing-queue}
       ELASTICSEARCH_DOMAIN_URL: ${ssm:/addresses-api/${self:provider.stage}/elasticsearch-domain}
+    events:
+      - schedule:
+          rate: cron(0 01 * * ? *)
+          input:
+            alias: "hackney_addresses"
+            fromIndex: "hackney_address"
+            deleteAfterReindex: true
+      - schedule:
+          rate: cron(0 02 * * ? *)
+          input:
+            alias: "national_addresses"
+            fromIndex: "national_address"
+            deleteAfterReindex: true
   switchElasticsearchAliasAfterReindex:
     name: ${self:service}-switch-es-alias-after-reindex-${self:provider.stage}
     handler: Reindex::Reindex.Handler::SwitchAlias


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/PA-418

## Describe this PR

### *What is the problem we're trying to solve*

We need to schedule the reindexing lambda to run and it needs to run for each index created by DMS.
### *What changes have we introduced*
- Add Cloudwatch events for each reindexing use case
- Add a cron job for each event
- Pass in specific inputs for each event

#### _Checklist_
- [X] Code pipeline builds correctly

### *Follow up actions after merging PR*

Check that both lambda runs passed in Staging.
Check that both lambda runs passed in Production.