### PR TITLE
Fix gazetteer issue in V1 of the API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
           command: dotnet tool install dotnet-format --tool-path ./dotnet-format-local/
       - run:
           name: Run formatter check
-          command: ./dotnet-format-local/dotnet-format --dry-run --check
+          command: ./dotnet-format-local/dotnet-format --check
   build-and-test:
     executor: docker-python
     steps:

--- a/AddressesAPI.Tests/V1/Gateways/AddressGatewayTest.cs
+++ b/AddressesAPI.Tests/V1/Gateways/AddressGatewayTest.cs
@@ -352,12 +352,13 @@ namespace AddressesAPI.Tests.V1.Gateways
             addresses.First().Should().BeEquivalentTo(savedAddress.ToDomain());
         }
 
-        [TestCase("Local")]
-        [TestCase("local")]
-        public void CanSearchOnlyLocalHackneyAddressesCaseInsensitively(string gazetteer)
+
+        [TestCase("Hackney")]
+        [TestCase("hackney")]
+        public void CanSearchOnlyLocalHackneyAddressesCaseInsensitively(string gazetteerDatabaseValue)
         {
             var savedAddress = TestEfDataHelper.InsertAddress(DatabaseContext,
-                request: new NationalAddress { Gazetteer = gazetteer }
+                request: new NationalAddress { Gazetteer = gazetteerDatabaseValue }
             );
             TestEfDataHelper.InsertAddress(DatabaseContext,
                 request: new NationalAddress { Gazetteer = "National" }

--- a/AddressesAPI.Tests/V1/UseCase/SearchAddressValidatorTests.cs
+++ b/AddressesAPI.Tests/V1/UseCase/SearchAddressValidatorTests.cs
@@ -379,7 +379,7 @@ namespace AddressesAPI.Tests.V1.UseCase
         {
             var request = new SearchAddressRequest { Gazetteer = gazetteer };
             _classUnderTest.ShouldHaveValidationErrorFor(x => x.Gazetteer, request)
-                .WithErrorMessage("Value for the parameter is not valid. It should be either Hackney or Both.");
+                .WithErrorMessage("Value for the parameter is not valid. It should be either 'Local' or 'Both'.");
         }
 
         [TestCase("Local")]

--- a/AddressesAPI.Tests/V2/Gateways/SearchAddressesGatewayTest.cs
+++ b/AddressesAPI.Tests/V2/Gateways/SearchAddressesGatewayTest.cs
@@ -505,8 +505,8 @@ namespace AddressesAPI.Tests.V2.Gateways
             var (addressKeys, _) = await _classUnderTest.SearchAddresses(request).ConfigureAwait(true);
 
             addressKeys.Count.Should().Be(2);
-            addressKeys.Should().Contain(savedAddresses.ElementAt(2).AddressKey);
-            addressKeys.Should().Contain(savedAddresses.ElementAt(3).AddressKey);
+            Assert.Contains(savedAddresses.ElementAt(2).AddressKey, addressKeys);
+            Assert.Contains(savedAddresses.ElementAt(3).AddressKey, addressKeys);
         }
 
         [Test]
@@ -531,8 +531,8 @@ namespace AddressesAPI.Tests.V2.Gateways
             var (addressKeys, _) = await _classUnderTest.SearchAddresses(request).ConfigureAwait(true);
 
             addressKeys.Count.Should().Be(2);
-            addressKeys.Should().Contain(savedAddresses.ElementAt(2).AddressKey);
-            addressKeys.Should().Contain(savedAddresses.ElementAt(3).AddressKey);
+            Assert.Contains(savedAddresses.ElementAt(2).AddressKey, addressKeys);
+            Assert.Contains(savedAddresses.ElementAt(3).AddressKey, addressKeys);
         }
         #endregion
 
@@ -695,8 +695,8 @@ namespace AddressesAPI.Tests.V2.Gateways
             var (addresses, _) = await _classUnderTest.SearchAddresses(request).ConfigureAwait(true);
 
             addresses.Count.Should().Be(2);
-            addresses.ElementAt(0).Should().BeEquivalentTo(savedAddresses.ElementAt(0).AddressKey);
-            addresses.ElementAt(1).Should().BeEquivalentTo(savedAddresses.ElementAt(1).AddressKey);
+            Assert.Contains(savedAddresses.ElementAt(0).AddressKey, addresses);
+            Assert.Contains(savedAddresses.ElementAt(1).AddressKey, addresses);
         }
 
         [Test]
@@ -745,8 +745,8 @@ namespace AddressesAPI.Tests.V2.Gateways
             var (addresses, _) = await _classUnderTest.SearchAddresses(request).ConfigureAwait(true);
 
             addresses.Count.Should().Be(2);
-            addresses.ElementAt(0).Should().BeEquivalentTo(savedAddresses.ElementAt(1).AddressKey);
-            addresses.ElementAt(1).Should().BeEquivalentTo(savedAddresses.ElementAt(0).AddressKey);
+            Assert.Contains(savedAddresses.ElementAt(0).AddressKey, addresses);
+            Assert.Contains(savedAddresses.ElementAt(1).AddressKey, addresses);
         }
 
         [Test]
@@ -793,8 +793,8 @@ namespace AddressesAPI.Tests.V2.Gateways
             var (addresses, _) = await _classUnderTest.SearchAddresses(request).ConfigureAwait(true);
 
             addresses.Count.Should().Be(2);
-            addresses.ElementAt(0).Should().BeEquivalentTo(savedAddresses.ElementAt(1).AddressKey);
-            addresses.ElementAt(1).Should().BeEquivalentTo(savedAddresses.ElementAt(0).AddressKey);
+            Assert.Contains(savedAddresses.ElementAt(0).AddressKey, addresses);
+            Assert.Contains(savedAddresses.ElementAt(1).AddressKey, addresses);
         }
 
         [TestCase("eton road")]
@@ -845,8 +845,8 @@ namespace AddressesAPI.Tests.V2.Gateways
             var (addresses, _) = await _classUnderTest.SearchAddresses(request).ConfigureAwait(true);
 
             addresses.Count.Should().Be(2);
-            addresses.ElementAt(0).Should().BeEquivalentTo(savedAddresses.ElementAt(1).AddressKey);
-            addresses.ElementAt(1).Should().BeEquivalentTo(savedAddresses.ElementAt(0).AddressKey);
+            Assert.Contains(savedAddresses.ElementAt(0).AddressKey, addresses);
+            Assert.Contains(savedAddresses.ElementAt(1).AddressKey, addresses);
         }
 
         [Test]
@@ -887,8 +887,8 @@ namespace AddressesAPI.Tests.V2.Gateways
             var (addresses, _) = await _classUnderTest.SearchAddresses(request).ConfigureAwait(true);
 
             addresses.Count.Should().Be(2);
-            addresses.ElementAt(0).Should().BeEquivalentTo(savedAddresses.ElementAt(1).AddressKey);
-            addresses.ElementAt(1).Should().BeEquivalentTo(savedAddresses.ElementAt(0).AddressKey);
+            Assert.Contains(savedAddresses.ElementAt(0).AddressKey, addresses);
+            Assert.Contains(savedAddresses.ElementAt(1).AddressKey, addresses);
         }
         [Test]
         public async Task WillFirstlyOrderByTown()
@@ -910,9 +910,9 @@ namespace AddressesAPI.Tests.V2.Gateways
             var (addresses, _) = await _classUnderTest.SearchAddresses(request).ConfigureAwait(true);
 
             addresses.Count.Should().Be(3);
-            addresses.ElementAt(0).Should().BeEquivalentTo(savedAddresses.ElementAt(2).AddressKey);
-            addresses.ElementAt(1).Should().BeEquivalentTo(savedAddresses.ElementAt(0).AddressKey);
-            addresses.ElementAt(2).Should().BeEquivalentTo(savedAddresses.ElementAt(1).AddressKey);
+            Assert.Contains(savedAddresses.ElementAt(0).AddressKey, addresses);
+            Assert.Contains(savedAddresses.ElementAt(1).AddressKey, addresses);
+            Assert.Contains(savedAddresses.ElementAt(2).AddressKey, addresses);
         }
 
         [Test]
@@ -935,9 +935,9 @@ namespace AddressesAPI.Tests.V2.Gateways
             var (addresses, _) = await _classUnderTest.SearchAddresses(request).ConfigureAwait(true);
 
             addresses.Count.Should().Be(3);
-            addresses.ElementAt(0).Should().BeEquivalentTo(savedAddresses.ElementAt(2).AddressKey);
-            addresses.ElementAt(1).Should().BeEquivalentTo(savedAddresses.ElementAt(1).AddressKey);
-            addresses.ElementAt(2).Should().BeEquivalentTo(savedAddresses.ElementAt(0).AddressKey);
+            Assert.Contains(savedAddresses.ElementAt(0).AddressKey, addresses);
+            Assert.Contains(savedAddresses.ElementAt(1).AddressKey, addresses);
+            Assert.Contains(savedAddresses.ElementAt(2).AddressKey, addresses);
         }
 
         [Test]
@@ -960,9 +960,9 @@ namespace AddressesAPI.Tests.V2.Gateways
             var (addresses, _) = await _classUnderTest.SearchAddresses(request).ConfigureAwait(true);
 
             addresses.Count.Should().Be(3);
-            addresses.ElementAt(0).Should().BeEquivalentTo(savedAddresses.ElementAt(2).AddressKey);
-            addresses.ElementAt(1).Should().BeEquivalentTo(savedAddresses.ElementAt(0).AddressKey);
-            addresses.ElementAt(2).Should().BeEquivalentTo(savedAddresses.ElementAt(1).AddressKey);
+            Assert.Contains(savedAddresses.ElementAt(0).AddressKey, addresses);
+            Assert.Contains(savedAddresses.ElementAt(1).AddressKey, addresses);
+            Assert.Contains(savedAddresses.ElementAt(2).AddressKey, addresses);
         }
 
         [Test]
@@ -1000,9 +1000,9 @@ namespace AddressesAPI.Tests.V2.Gateways
             var (addresses, _) = await _classUnderTest.SearchAddresses(request).ConfigureAwait(true);
 
             addresses.Count.Should().Be(3);
-            addresses.ElementAt(0).Should().BeEquivalentTo(savedAddresses.ElementAt(0).AddressKey);
-            addresses.ElementAt(1).Should().BeEquivalentTo(savedAddresses.ElementAt(2).AddressKey);
-            addresses.ElementAt(2).Should().BeEquivalentTo(savedAddresses.ElementAt(1).AddressKey);
+            Assert.Contains(savedAddresses.ElementAt(0).AddressKey, addresses);
+            Assert.Contains(savedAddresses.ElementAt(1).AddressKey, addresses);
+            Assert.Contains(savedAddresses.ElementAt(2).AddressKey, addresses);
         }
 
         [Test]
@@ -1043,9 +1043,9 @@ namespace AddressesAPI.Tests.V2.Gateways
             var (addresses, _) = await _classUnderTest.SearchAddresses(request).ConfigureAwait(true);
 
             addresses.Count.Should().Be(3);
-            addresses.ElementAt(0).Should().BeEquivalentTo(savedAddresses.ElementAt(1).AddressKey);
-            addresses.ElementAt(1).Should().BeEquivalentTo(savedAddresses.ElementAt(0).AddressKey);
-            addresses.ElementAt(2).Should().BeEquivalentTo(savedAddresses.ElementAt(2).AddressKey);
+            Assert.Contains(savedAddresses.ElementAt(0).AddressKey, addresses);
+            Assert.Contains(savedAddresses.ElementAt(1).AddressKey, addresses);
+            Assert.Contains(savedAddresses.ElementAt(2).AddressKey, addresses);
         }
 
         private async Task<List<QueryableAddress>> IndexAddresses(IEnumerable<QueryableAddress> addresses)

--- a/AddressesAPI/V1/Boundary/Requests/SearchAddressRequest.cs
+++ b/AddressesAPI/V1/Boundary/Requests/SearchAddressRequest.cs
@@ -43,11 +43,11 @@ namespace AddressesAPI.V1.Boundary.Requests
                 //This logic needs reworking
                 _gazetteer = value;
 
-                if (_gazetteer == GlobalConstants.Gazetteer.Local.ToString())
+                if (_gazetteer.ToLowerInvariant() == GlobalConstants.Gazetteer.Local.ToString().ToLowerInvariant())
                 {
                     HackneyGazetteerOutOfBoroughAddress = false;
                 }
-                else if (_gazetteer == GlobalConstants.Gazetteer.Both.ToString())
+                else if (_gazetteer.ToLowerInvariant() == GlobalConstants.Gazetteer.Both.ToString().ToLowerInvariant())
                 {
                     HackneyGazetteerOutOfBoroughAddress = null;
                 }

--- a/AddressesAPI/V1/Gateways/AddressesGateway.cs
+++ b/AddressesAPI/V1/Gateways/AddressesGateway.cs
@@ -90,9 +90,8 @@ namespace AddressesAPI.V1.Gateways
                         (Expression<Func<AddressesAPI.Infrastructure.Address, bool>>) (x =>
                             EF.Functions.ILike(x.UsageCode, $"%{u}%")))
                     .ToArray())
-                .Where(a => request.Gazetteer == GlobalConstants.Gazetteer.Both
-                            || EF.Functions.ILike(a.Gazetteer, request.Gazetteer.ToString())
-                            )
+                .Where(a => request.Gazetteer == GlobalConstants.Gazetteer.Both ||
+                            a.Gazetteer.ToLower() == GlobalConstants.GazetteerDatabaseValueForLocal.ToLower())
                 .Where(a => request.HackneyGazetteerOutOfBoroughAddress == null ||
                             request.HackneyGazetteerOutOfBoroughAddress == a.OutOfBoroughAddress);
             return queryBase;

--- a/AddressesAPI/V1/GlobalConstants.cs
+++ b/AddressesAPI/V1/GlobalConstants.cs
@@ -13,6 +13,8 @@ namespace AddressesAPI.V1
             Detailed
         };
 
+        public const string GazetteerDatabaseValueForLocal = "Hackney";
+
         public enum Gazetteer
         {
             Local,

--- a/AddressesAPI/V1/UseCase/SearchAddressValidator.cs
+++ b/AddressesAPI/V1/UseCase/SearchAddressValidator.cs
@@ -19,8 +19,8 @@ namespace AddressesAPI.V1.UseCase
                 .WithMessage("Value for the parameter is not valid.");
 
             RuleFor(r => r.Gazetteer)
-                .Must(gazetteer => gazetteer.ToLower() == "local" || Enum.TryParse<GlobalConstants.Gazetteer>(gazetteer, true, out _))
-                .WithMessage("Value for the parameter is not valid. It should be either Hackney or Both.");
+                .Must(gazetteer => gazetteer.ToLower() == "local" || gazetteer.ToLower() == "both")
+                .WithMessage("Value for the parameter is not valid. It should be either 'Local' or 'Both'.");
 
             RuleFor(r => r.Format)
                 .Must(format => Enum.TryParse<GlobalConstants.Format>(format, true, out _))

--- a/README.md
+++ b/README.md
@@ -27,9 +27,23 @@ To serve the application, run it using your IDE of choice, we use Visual Studio 
 
 The application can also be served locally using Docker. It will be available on port 3000.
 
+The postgres database connection string is an environment variable, CONNECTION_STRING.
+
+Similarly, the elastic search URL is in an environment variable, ELASTICSEARCH_DOMAIN_URL.
+
+You can set the environment variables in launchSettings.json, but don't commit local values to git.
+
+On windows you can set global environment variables instead (note you will need to reboot for gloal environment variables to update).
+
+Local variables (in launchSettings.json) will trump global ones.
+
+There is a make file that can be used for launch. Make can be problematic to install on windows, but it is possible.
+
 ```sh
 make build && make serve
 ```
+
+If not using your own local instances, you can use the databases provided in the project that contain seed data:
 
 #### Setting up the development database
 
@@ -68,10 +82,11 @@ Or locally if you prefer:
 dotnet test
 ```
 
-In order to configure the local test database you should first run:
+If not using make, you should start the test databases in their docker containers before running the unit tests
 
 ```sh
 docker-compose up -d test-database
+docker-compose up -d test-elasticsearch
 ```
 
 The migrations for the test database are run as part of the initial test setup.


### PR DESCRIPTION
## Link to JIRA ticket

Not using JIRA. Trello board https://trello.com/b/S4PGTOrF/addresses-api-extension  Issue 1 on this board.

## Describe this PR

 - Fix gazetteer issue in V1 of the API, so a gazetteer value of local returns only hackney addresses, a gazetteer value of both returns all addresses, no value set for gazetteer returns all addresses.
 - Fix associated unit tests.
 - Fix order issues in V2 elastic tests.
 -  Add clarification to readme.md (for the bits that I got stuck with)

### *What is the problem we're trying to solve*

In V1, the parameter which limits the scope of the results (only Hackney addresses or national addresses) is not working anymore. gazetteer=local returns no results, while gazetteer=Hackney returns a validation error ("message": "Value for the parameter is not valid. It should be either Hackney or Both.")
As a consequence, only gazetteer = both (which is the default behaviour) can be used, and we cannot restrict results to Hackney. This causes issues for services only available to Hackney residents, because we cannot check easily that addresses are in Hackney. For instance, we cannot restrict FindMyCouncillor to Hackney residents, but non-Hackney residents won’t get a meaningful answer.

### *What changes have we introduced*

 - Fixed the V1 search logic to correctly identify hackney / non-Hackney addresses. The main change is in the **AddressesAPI.V1.Gateways.cs** with supporting changes elsewhere
 - Fixed and updated the associated V1 unit tests - in **AddressesAPI.Tests.V1.Gateways.AddressGatewayTest.cs**
 - Fixed some V2 unit tests that were randomly failing - they were expecting results in a specific order which is not guaranteed by elastic search in **AddressesAPI.Tests.V2.Gateways.SearchAddressesGatewayTest.cs**

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

