### PR TITLE
Remove postcode partial matching as it overrides the other address co…

### DIFF
--- a/AddressesAPI/V2/Gateways/ElasticGateway.cs
+++ b/AddressesAPI/V2/Gateways/ElasticGateway.cs
@@ -131,18 +131,7 @@ namespace AddressesAPI.V2.Gateways
                 .ZeroTermsQuery(ZeroTermsQuery.All)
                 .Query(request.AddressQuery));
 
-            // This allows partial matching on postcode (this isn't a requirement for the other components of the address).
-            // It assumes the postcode is the last component of request.AddressQuery (if it isn't it shouldn't have any impact).
-            var components = request.AddressQuery.Split(',');
-            if (components != null && components.Length > 0)
-            {
-                var matchPartialPostcode = SearchPostcodes(components[components.Length - 1].Trim(), q);
-                return (fuzzyMatchText && exactlyMatchNumbers) || (orderedMatch) || (exactMatch) || (matchPartialPostcode);
-            }
-            else
-            {
-                return (fuzzyMatchText && exactlyMatchNumbers && matchFullLines) || (orderedMatch) || (exactMatch);
-            }
+            return (fuzzyMatchText && exactlyMatchNumbers && matchFullLines) || (orderedMatch) || (exactMatch);
         }
 
         private static SortDescriptor<QueryableAddress> SortResults(SortDescriptor<QueryableAddress> srt)
@@ -190,13 +179,8 @@ namespace AddressesAPI.V2.Gateways
 
         private static QueryContainer SearchPostcodes(SearchParameters request, QueryContainerDescriptor<QueryableAddress> q)
         {
-            return SearchPostcodes(request.Postcode, q);
-        }
-
-        private static QueryContainer SearchPostcodes(string postCode, QueryContainerDescriptor<QueryableAddress> q)
-        {
-            if (string.IsNullOrWhiteSpace(postCode)) return null;
-            var postcodeSearchTerm = postCode?.Replace(" ", "").ToLower();
+            if (string.IsNullOrWhiteSpace(request.Postcode)) return null;
+            var postcodeSearchTerm = request.Postcode?.Replace(" ", "").ToLower();
             var searchPostcodes = q.Wildcard(m =>
                 m.Field(f => f.Postcode).Value($"{postcodeSearchTerm}*"));
             return searchPostcodes;


### PR DESCRIPTION
## Link to JIRA ticket
https://trello.com/c/cSE9PSfH/23-issue-3b-full-text-search-in-v2-postcodes

## Describe this PR
Remove postcode partial matching as it overrides the other address components and returns seemingly random results.
It was a 'nice to have' to be able to search partial postcodes in the 'query' element of address-search. But testing highlighted that it was too permissive, so we have reverted to searching on postcode 'blocks' only.
(partial postcode search can still be performed using the 'postcode' element)

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

