### PR TITLE
Remove subnet_id for elasticsearch as it was causing a terraform error

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -86,7 +86,7 @@ module "elasticsearch_db_production" {
   environment_name = "production"
   port             = 443
   domain_name      = "addresses-api-es"
-  subnet_ids       = [tolist(data.aws_subnet_ids.production.ids)[0], tolist(data.aws_subnet_ids.production.ids)[1]]
+  subnet_ids       = [tolist(data.aws_subnet_ids.production.ids)[0]]
   project_name     = "addresses-api"
   es_version       = "7.8"
   encrypt_at_rest  = "true"


### PR DESCRIPTION
## Link to JIRA ticket
https://trello.com/b/S4PGTOrF/addresses-api-extension

## Describe this PR
Remove subnet_id for elasticsearch as it was causing a terraform error

### *What is the problem we're trying to solve*
Error in the build pipeline for production whilst applying the terraform:

Error: ValidationException: You must specify exactly one subnet.
│ 
│   with module.elasticsearch_db_production.aws_elasticsearch_domain.lbh_es,
│   on .terraform/modules/elasticsearch_db_production/modules/database/elasticsearch/main.tf line 14, in resource "aws_elasticsearch_domain" "lbh_es":
│   14: resource "aws_elasticsearch_domain" "lbh_es" {

### *What changes have we introduced*
removed the second subnet_id  from production terraform file

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly
