### PR TITLE
Fix VPC name for pipeline

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -31,7 +31,7 @@ terraform {
 
 data "aws_vpc" "production_vpc" {
   tags = {
-    Name = "apis-prod"
+    Name = "vpc-production-apis-production"
   }
 }
 

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -31,7 +31,7 @@ terraform {
 
 data "aws_vpc" "production_vpc" {
   tags = {
-    Name = "vpc-production-apis-production"
+    Name = "apis-prod"
   }
 }
 

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -33,7 +33,7 @@ terraform {
 
 data "aws_vpc" "staging_vpc" {
   tags = {
-    Name = "vpc-staging-apis-staging"
+    Name = "apis-stg"
   }
 }
 


### PR DESCRIPTION
- Many moons ago, the VPC names were updated as per of the move to network hubs.
- The last time this pipeline was used was before many moons ago