### PR TITLE
Increase volume size

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -93,7 +93,7 @@ module "elasticsearch_db_production" {
   instance_type    = "t3.medium.elasticsearch"
   instance_count   = "6"
   ebs_enabled      = "true"
-  ebs_volume_size  = "40"
+  ebs_volume_size  = "60"
   region           = data.aws_region.current.name
   account_id       = data.aws_caller_identity.current.account_id
 }


### PR DESCRIPTION
- For the production ElasticSearch cluster (Addresses API), the EBS volume size has been increased manually outside of terraform. This means that terraform plan is generating a step back down to the original configuration.
- Therefore, step the volume size up to match the current setting 
![image](https://user-images.githubusercontent.com/8542878/223196955-3f4b8bee-bd45-4fce-bf05-e8b07848033e.png)
