### PR TITLE
Disable national address schedule

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,8 +213,7 @@ workflows:
       - check-code-formatting:
           context: api-nuget-token-context
       - build-and-test:
-          context:
-            - api-nuget-token-context
+          context: api-nuget-token-context
       - assume-role-development:
           context: api-assume-role-development-context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,8 +210,11 @@ jobs:
 workflows:
   check-and-deploy-development:
     jobs:
-      - check-code-formatting
-      - build-and-test
+      - check-code-formatting:
+          context: api-nuget-token-context
+      - build-and-test:
+          context:
+            - api-nuget-token-context
       - assume-role-development:
           context: api-assume-role-development-context
           requires:
@@ -234,6 +237,8 @@ workflows:
   check-and-deploy-staging-and-production:
     jobs:
       - build-and-test:
+          context:
+            - api-nuget-token-context
         filters:
           branches:
             only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,9 +239,9 @@ workflows:
       - build-and-test:
           context:
             - api-nuget-token-context
-        filters:
-          branches:
-            only: master
+          filters:
+            branches:
+              only: master
       - assume-role-staging:
           context: api-assume-role-staging-context
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,10 +210,8 @@ jobs:
 workflows:
   check-and-deploy-development:
     jobs:
-      - check-code-formatting:
-          context: api-nuget-token-context
-      - build-and-test:
-          context: api-nuget-token-context
+      - check-code-formatting
+      - build-and-test
       - assume-role-development:
           context: api-assume-role-development-context
           requires:
@@ -236,8 +234,6 @@ workflows:
   check-and-deploy-staging-and-production:
     jobs:
       - build-and-test:
-          context:
-            - api-nuget-token-context
           filters:
             branches:
               only: master

--- a/serverless.yml
+++ b/serverless.yml
@@ -45,6 +45,7 @@ functions:
             fromIndex: "hackney_address"
             deleteAfterReindex: true
       - schedule:
+          enabled: false
           rate: cron(0 02 * * ? *)
           input:
             alias: "national_addresses"


### PR DESCRIPTION
## [HPT-33](https://hackney.atlassian.net/browse/HPT-33) Update addresses Elasticsearch index with latest data

Currently the national addresses elasticsearch is being updated by a Database Migration Service process with Change Data Capture - this is pointing to an Elasticsearch Index `national_addresses_202312010200` .

However, the process triggered by this event still tries to create new indexes as `national_addresses_{todays_date}` but fails to migrate the data from the old index to the new.

This creates a new almost empty elasticsearch index each day, which can become a problem.

![image](https://github.com/LBHackney-IT/addresses-api/assets/74552077/37ce63ae-ce97-4b3c-a54f-de2990e0817e)

The hackney_addresses process is still creating a new index each day with new data, switching the alias to the new one, and deleting the previous day's index.

As background, overnight processes are run on the addresses API that create new indexes and alias them to the hackney_addresses and national_addresses aliases

For more context, see:

https://github.com/LBHackney-IT/addresses-api/blob/master/docs/elasticsearch_setup.md


[HPT-33]: https://hackney.atlassian.net/browse/HPT-33?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ