### PR TITLE
Remove CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,0 @@
-# doc for this file https://help.github.com/articles/about-code-owners/
-
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @global-owner1 and @global-owner2 will be requested for
-# review when someone opens a pull request.
-
-* @LBHMGeorgieva @LBHMKeyworth @LBHSPreston @LBHRShetty


### PR DESCRIPTION
The `CODEOWNERS` file was added 4 years ago, but it's now out of date and contains errors.

`CODEOWNERS` is used to automatically request review and we'll shortly require a review from at least one person in this list in order to merge. The people in this list often aren't the people needed to review it, and people who do need to review it aren't in the list.

We've not yet decided on an owner for this repository, so in the meantime we can remove `CODEOWNERS`  entirely. This will mean reviews can be approved by anyone with write access to the repository (the entire LBHackney-IT organisation, so the existing workflows can continue once the global rules are enforced.
Once we have a clear owner, we can re-create this file easily enough.
