### PR TITLE
Increase api lambdas timeout and resources

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -13,6 +13,8 @@ functions:
     name: ${self:service}-${self:provider.stage}
     handler: AddressesAPI::AddressesAPI.LambdaEntryPoint::FunctionHandlerAsync
     role: lambdaExecutionRole
+    timeout: 300
+    memorySize: 2048
     package:
       artifact: ./AddressesAPI/bin/release/net6.0/addresses-api.zip
     environment:


### PR DESCRIPTION
## Link to JIRA ticket

N/A

## Describe this PR

### *What is the problem we're trying to solve*

Lambda function is timing out after 6s when using the new property hierarchy flag. This update increases the timeout, so we can check if that helps initially. We'll investigate further to see if the queries and records handling in general could be improved as well.

### *What changes have we introduced*

Increase lambda timeout to 5mins and double the memory to 2MB.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
