### PR TITLE
disable queries by parent uprn

### DIFF
--- a/AddressesAPI.Tests/V1/Gateways/AddressGatewayTest.cs
+++ b/AddressesAPI.Tests/V1/Gateways/AddressGatewayTest.cs
@@ -246,7 +246,8 @@ namespace AddressesAPI.Tests.V1.Gateways
         }
 
         [Test]
-        public void WillSearchParentUprndsForAMatch()
+        [Ignore("Disabled until we have optimised tables for parent UPRN queries")]
+        public void WillSearchParentUPRNsForAMatch()
         {
             var matchingAddress = TestEfDataHelper.InsertAddress(DatabaseContext,
                 request: new NationalAddress { ParentUPRN = 11111111 }
@@ -956,7 +957,9 @@ namespace AddressesAPI.Tests.V1.Gateways
         //In order to get all the children for the parent an additional search must be made
         // to find all the addresses that have a parentUPRN matching any of the parentUPRNs in the original search
         // and combining the results before building the hierarchy.
+
         [Test]
+        [Ignore("Disabled until we have optimised tables for parent UPRN queries")]
         public void ItWillIncludeChildRecordsToTheHierarchyEvenIfTheyAreNotIncludedInTheOriginalResultsSet()
         {
             var parentUprn = _faker.Random.Number(10000000, 99999999);
@@ -1075,6 +1078,7 @@ namespace AddressesAPI.Tests.V1.Gateways
         }
 
         [Test]
+        [Ignore("Disabled until we have optimised tables for parent UPRN queries")]
         public void ItWillKeepTheCorrectOrderOfChildRecordsWithinTheHierarchy()
         {
             var parentUprn = _faker.Random.Number(10000000, 99999999);

--- a/AddressesAPI/V1/Gateways/AddressesGateway.cs
+++ b/AddressesAPI/V1/Gateways/AddressesGateway.cs
@@ -83,42 +83,44 @@ namespace AddressesAPI.V1.Gateways
             //build initial hierarchy based on parents
             var hierarchyWithAllParents = BuildHierarchyForParent(null, addresses);
 
+            //// DISABLED UNTIL WE HAVE OPTIMISED THE TABLES FOR PARENT UPRN QUERIES ////
             //ensure we are not missing children from the results set
             //this is typically when a child address is outside the parent's post code
-            var distinctParents = hierarchyWithAllParents
-                .Where(x => x.ParentUPRN == null)
-                .Select(a => a).Distinct();
 
-            foreach (var parent in distinctParents)
-            {
-                var originalChildCount = parent.ChildAddresses?.Count;
+            //var distinctParents = hierarchyWithAllParents
+            //    .Where(x => x.ParentUPRN == null)
+            //    .Select(a => a).Distinct();
+
+            //foreach (var parent in distinctParents)
+            //{
+            //    var originalChildCount = parent.ChildAddresses?.Count;
 
 
-                var getAllChildrenByParentUPRNQuery = new SearchParameters()
-                {
-                    Format = originalRequest.Format,
-                    Gazetteer = originalRequest.Gazetteer,
-                    ParentUprn = parent.UPRN,
-                };
+            //    var getAllChildrenByParentUPRNQuery = new SearchParameters()
+            //    {
+            //        Format = originalRequest.Format,
+            //        Gazetteer = originalRequest.Gazetteer,
+            //        ParentUprn = parent.UPRN,
+            //    };
 
-                var baseQuery = CompileBaseSearchQuery(getAllChildrenByParentUPRNQuery);
+            //    var baseQuery = CompileBaseSearchQuery(getAllChildrenByParentUPRNQuery).ToList();
 
-                var formattedChildAddress = baseQuery.Select(
-                    a => getAllChildrenByParentUPRNQuery.Format == GlobalConstants.Format.Simple
-                    ? a.ToSimpleDomain() : a.ToDomain())
-                    .ToList();
+            //    var formattedChildAddress = baseQuery.Select(
+            //        a => getAllChildrenByParentUPRNQuery.Format == GlobalConstants.Format.Simple
+            //        ? a.ToSimpleDomain() : a.ToDomain())
+            //        .ToList();
 
-                if (formattedChildAddress.Count > 0)
-                {
-                    parent.ChildAddresses
-                        .AddRange(formattedChildAddress
-                            .Where(child => !parent.ChildAddresses
-                                .Any(x => x.UPRN == child.UPRN)));
+            //    if (formattedChildAddress.Count > 0)
+            //    {
+            //        parent.ChildAddresses
+            //            .AddRange(formattedChildAddress
+            //                .Where(child => !parent.ChildAddresses
+            //                    .Any(x => x.UPRN == child.UPRN)));
 
-                    //increase total count by new child accounts count
-                    totalCount += (int)(parent.ChildAddresses.Count - originalChildCount);
-                }
-            }
+            //        //increase total count by new child accounts count
+            //        totalCount += (int)(parent.ChildAddresses.Count - originalChildCount);
+            //    }
+            //}
 
             //order parents again to ensure parents added to the initial result set appear in the correct position
             var orderedByparentsHierarchy = OrderDomainAddresses(hierarchyWithAllParents);
@@ -210,7 +212,8 @@ namespace AddressesAPI.V1.Gateways
                             EF.Functions.ILike(a.Street.Replace(" ", ""), streetSearchTerm))
                 .Where(a => addressStatusSearchTerms == null || addressStatusSearchTerms.Contains(a.AddressStatus.ToLower()))
                 .Where(a => request.Uprn == null || a.UPRN == request.Uprn)
-                .Where(a => request.ParentUprn == null || a.ParentUPRN == request.ParentUprn)
+                //// DISABLED UNTIL WE HAVE OPTIMISED THE TABLES FOR PARENT UPRN QUERIES ////
+                //.Where(a => request.ParentUprn == null || a.ParentUPRN == request.ParentUprn)
                 .Where(a => request.Usrn == null
                             || a.USRN == request.Usrn)
                 .Where(a => (usageSearchTerms == null || !usageSearchTerms.Any())

--- a/serverless.yml
+++ b/serverless.yml
@@ -13,8 +13,6 @@ functions:
     name: ${self:service}-${self:provider.stage}
     handler: AddressesAPI::AddressesAPI.LambdaEntryPoint::FunctionHandlerAsync
     role: lambdaExecutionRole
-    timeout: 300
-    memorySize: 2048
     package:
       artifact: ./AddressesAPI/bin/release/net6.0/addresses-api.zip
     environment:


### PR DESCRIPTION
## Link to JIRA ticket

[TS-1693](https://hackney.atlassian.net/browse/TS-1693)

## Describe this PR

### *What is the problem we're trying to solve*

When we added the support for property hierarchies in the search results we included some edge cases for fetching parent and child addresses when they were outside the original result set's post code. We introduced new query by parent UPRN which turned out to be too heavy for the database to handle in its current configuration and the queries keep timing out.

### *What changes have we introduced*

This update temporarily disables the heavy "by parent UPRN" queries until we've had a chance to optimise the tables and views for these queries. 

Also reverts the temporary lambda resource tweaks.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

Check that the hierarchy results are now returned in a timely fashion.


[TS-1693]: https://hackney.atlassian.net/browse/TS-1693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ