### PR TITLE
TS-1693 enable parent uprn queries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,13 +295,13 @@ workflows:
           filters:
             branches:
               only: master
-      - migrate-database-staging:
-          requires:
-            - terraform-init-and-apply-to-staging
-            - assume-role-staging
-          filters:
-            branches:
-              only: master
+      # - migrate-database-staging:
+      #     requires:
+      #       - terraform-init-and-apply-to-staging
+      #       - assume-role-staging
+      #     filters:
+      #       branches:
+      #         only: master
       - deploy-to-staging:
           requires:
             - assume-role-staging
@@ -335,13 +335,13 @@ workflows:
           filters:
             branches:
               only: master
-      - migrate-database-production:
-          requires:
-            - terraform-init-and-apply-to-production
-            - assume-role-production
-          filters:
-            branches:
-              only: master
+      # - migrate-database-production:
+      #     requires:
+      #       - terraform-init-and-apply-to-production
+      #       - assume-role-production
+      #     filters:
+      #       branches:
+      #         only: master
       - permit-production-release:
           type: approval
           requires:

--- a/AddressesAPI.Tests/V1/Gateways/AddressGatewayTest.cs
+++ b/AddressesAPI.Tests/V1/Gateways/AddressGatewayTest.cs
@@ -246,7 +246,6 @@ namespace AddressesAPI.Tests.V1.Gateways
         }
 
         [Test]
-        [Ignore("Disabled until we have optimised tables for parent UPRN queries")]
         public void WillSearchParentUPRNsForAMatch()
         {
             var matchingAddress = TestEfDataHelper.InsertAddress(DatabaseContext,
@@ -959,7 +958,6 @@ namespace AddressesAPI.Tests.V1.Gateways
         // and combining the results before building the hierarchy.
 
         [Test]
-        [Ignore("Disabled until we have optimised tables for parent UPRN queries")]
         public void ItWillIncludeChildRecordsToTheHierarchyEvenIfTheyAreNotIncludedInTheOriginalResultsSet()
         {
             var parentUprn = _faker.Random.Number(10000000, 99999999);
@@ -1078,7 +1076,6 @@ namespace AddressesAPI.Tests.V1.Gateways
         }
 
         [Test]
-        [Ignore("Disabled until we have optimised tables for parent UPRN queries")]
         public void ItWillKeepTheCorrectOrderOfChildRecordsWithinTheHierarchy()
         {
             var parentUprn = _faker.Random.Number(10000000, 99999999);

--- a/AddressesAPI/V1/Gateways/AddressesGateway.cs
+++ b/AddressesAPI/V1/Gateways/AddressesGateway.cs
@@ -83,44 +83,43 @@ namespace AddressesAPI.V1.Gateways
             //build initial hierarchy based on parents
             var hierarchyWithAllParents = BuildHierarchyForParent(null, addresses);
 
-            //// DISABLED UNTIL WE HAVE OPTIMISED THE TABLES FOR PARENT UPRN QUERIES ////
             //ensure we are not missing children from the results set
             //this is typically when a child address is outside the parent's post code
 
-            //var distinctParents = hierarchyWithAllParents
-            //    .Where(x => x.ParentUPRN == null)
-            //    .Select(a => a).Distinct();
+            var distinctParents = hierarchyWithAllParents
+                .Where(x => x.ParentUPRN == null)
+                .Select(a => a).Distinct();
 
-            //foreach (var parent in distinctParents)
-            //{
-            //    var originalChildCount = parent.ChildAddresses?.Count;
+            foreach (var parent in distinctParents)
+            {
+                var originalChildCount = parent.ChildAddresses?.Count;
 
 
-            //    var getAllChildrenByParentUPRNQuery = new SearchParameters()
-            //    {
-            //        Format = originalRequest.Format,
-            //        Gazetteer = originalRequest.Gazetteer,
-            //        ParentUprn = parent.UPRN,
-            //    };
+                var getAllChildrenByParentUPRNQuery = new SearchParameters()
+                {
+                    Format = originalRequest.Format,
+                    Gazetteer = originalRequest.Gazetteer,
+                    ParentUprn = parent.UPRN,
+                };
 
-            //    var baseQuery = CompileBaseSearchQuery(getAllChildrenByParentUPRNQuery).ToList();
+                var baseQuery = CompileBaseSearchQuery(getAllChildrenByParentUPRNQuery).ToList();
 
-            //    var formattedChildAddress = baseQuery.Select(
-            //        a => getAllChildrenByParentUPRNQuery.Format == GlobalConstants.Format.Simple
-            //        ? a.ToSimpleDomain() : a.ToDomain())
-            //        .ToList();
+                var formattedChildAddress = baseQuery.Select(
+                    a => getAllChildrenByParentUPRNQuery.Format == GlobalConstants.Format.Simple
+                    ? a.ToSimpleDomain() : a.ToDomain())
+                    .ToList();
 
-            //    if (formattedChildAddress.Count > 0)
-            //    {
-            //        parent.ChildAddresses
-            //            .AddRange(formattedChildAddress
-            //                .Where(child => !parent.ChildAddresses
-            //                    .Any(x => x.UPRN == child.UPRN)));
+                if (formattedChildAddress.Count > 0)
+                {
+                    parent.ChildAddresses
+                        .AddRange(formattedChildAddress
+                            .Where(child => !parent.ChildAddresses
+                                .Any(x => x.UPRN == child.UPRN)));
 
-            //        //increase total count by new child accounts count
-            //        totalCount += (int)(parent.ChildAddresses.Count - originalChildCount);
-            //    }
-            //}
+                    //increase total count by new child accounts count
+                    totalCount += (int)(parent.ChildAddresses.Count - originalChildCount);
+                }
+            }
 
             //order parents again to ensure parents added to the initial result set appear in the correct position
             var orderedByparentsHierarchy = OrderDomainAddresses(hierarchyWithAllParents);
@@ -212,8 +211,7 @@ namespace AddressesAPI.V1.Gateways
                             EF.Functions.ILike(a.Street.Replace(" ", ""), streetSearchTerm))
                 .Where(a => addressStatusSearchTerms == null || addressStatusSearchTerms.Contains(a.AddressStatus.ToLower()))
                 .Where(a => request.Uprn == null || a.UPRN == request.Uprn)
-                //// DISABLED UNTIL WE HAVE OPTIMISED THE TABLES FOR PARENT UPRN QUERIES ////
-                //.Where(a => request.ParentUprn == null || a.ParentUPRN == request.ParentUprn)
+                .Where(a => request.ParentUprn == null || a.ParentUPRN == request.ParentUprn)
                 .Where(a => request.Usrn == null
                             || a.USRN == request.Usrn)
                 .Where(a => (usageSearchTerms == null || !usageSearchTerms.Any())


### PR DESCRIPTION
## Link to JIRA ticket

[TS-1693](https://hackney.atlassian.net/browse/TS-1693)

## Describe this PR

### *What is the problem we're trying to solve*

When we first added the parent uprn queries the database couldn't handle them due to missing indexes. We now have those indexes in place and the queries run fast. 

Please note the migrations in this project and the actual database schema are so out of sync that it has to be dealt with separately. That's why the index wasn't added using a migration. For that same reason database migrations have been disabled in the pipeline for now until we've had a chance to get things back in sync.

### *What changes have we introduced*

Enable the parent uprn queries disabled in the previous PR.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

N/A

[TS-1693]: https://hackney.atlassian.net/browse/TS-1693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ