### PR TITLE
TS-1693 set page count to one on hierarchy requests

### DIFF
--- a/AddressesAPI.Tests/V1/UseCase/SearchAddressUseCaseTest.cs
+++ b/AddressesAPI.Tests/V1/UseCase/SearchAddressUseCaseTest.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Collections.Generic;
 using AddressesAPI.Tests.V1.Helper;
 using AddressesAPI.V1;
 using AddressesAPI.V1.Boundary.Requests;
@@ -14,6 +12,8 @@ using FluentAssertions;
 using FluentValidation.Results;
 using Moq;
 using NUnit.Framework;
+using System;
+using System.Collections.Generic;
 
 namespace AddressesAPI.Tests.V1.UseCase
 {
@@ -195,6 +195,26 @@ namespace AddressesAPI.Tests.V1.UseCase
             result.Setup(x => x.IsValid).Returns(valid);
             _fakeValidator.Setup(x => x.Validate(It.IsAny<SearchAddressRequest>()))
                 .Returns(result.Object);
+        }
+
+        [Test]
+        public void GivenHierarchyAsStructure_WhenExecuteAsync_ReturnsPageCountOneRegardlessOfTotalCount()
+        {
+            SetupValidatorToReturnValid();
+
+            var request = new SearchAddressRequest
+            {
+                Structure = GlobalConstants.Structure.Hierarchy.ToString()
+            };
+
+            var addresses = new List<Address> { };
+
+            //total count set to 1000 which normally results in 20 pages by default
+            _fakeGateway.Setup(s => s.SearchAddresses(It.IsAny<SearchParameters>())).Returns((addresses, 1000));
+
+            var response = _classUnderTest.ExecuteAsync(request);
+
+            response.PageCount.Should().Be(1);
         }
     }
 }

--- a/AddressesAPI/V1/UseCase/SearchAddressUseCase.cs
+++ b/AddressesAPI/V1/UseCase/SearchAddressUseCase.cs
@@ -33,11 +33,12 @@ namespace AddressesAPI.V1.UseCase
 
             if (results == null)
                 return new SearchAddressResponse();
+
             var useCaseResponse = new SearchAddressResponse
             {
                 Addresses = results.ToResponse(),
                 TotalCount = totalCount,
-                PageCount = totalCount.CalculatePageCount(request.PageSize)
+                PageCount = searchParameters.Structure == GlobalConstants.Structure.Hierarchy ? 1 : totalCount.CalculatePageCount(request.PageSize)
             };
 
             return useCaseResponse;


### PR DESCRIPTION
## Link to JIRA ticket

[TS-1693](https://hackney.atlassian.net/browse/TS-1693)

## Describe this PR

### *What is the problem we're trying to solve*

We don't currently support paging when `structure` is set to `hierarchy` in the request. However the use case still calculates the page count based on the default page size of 50. We don't need to calculate the page count and can set it to one.

### *What changes have we introduced*

Set the page count to one in the response whenever hierarchy is requested.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

N/A


[TS-1693]: https://hackney.atlassian.net/browse/TS-1693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ