### PR TITLE
TS-1882 Improve sorting for hierarchical results

### DIFF
--- a/AddressesAPI/AddressesAPI.csproj
+++ b/AddressesAPI/AddressesAPI.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="5.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.36" />
+    <PackageReference Include="NaturalSort.Extension" Version="4.3.0" />
     <PackageReference Include="NEST" Version="7.10.0" />
     <PackageReference Include="NEST.JsonNetSerializer" Version="7.10.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />


### PR DESCRIPTION
## Link to JIRA ticket

[TS-1882](https://hackney.atlassian.net/browse/TS-1882)

## Describe this PR

### *What is the problem we're trying to solve*

Current sorting for hierarchical results doesn't show records in the correct order. There are issue with numbers sorted as strings for  example where the results are not in the order user would expect them to be. Also because some parents don't have post codes including post codes in the sort causes results to be in the wrong order.

### *What changes have we introduced*

1. Simplify the sorting for hierarchical results to only include town and line 1
2. `NaturalSort.Extension` library has been implemented to handle the line 1 sorting, so that the results always appear in the order user would expect regardles whether the value includes numbers. This also handles the various scenarios where numbers can be anywhere in the string
3. Remove redundant tests
4. Update existing tests to reflect the new sorting

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

N/A


[TS-1882]: https://hackney.atlassian.net/browse/TS-1882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ