### PR TITLE
Rename historical status to historic

### DIFF
--- a/AddressesAPI.Tests/V1/E2ETests/SearchAddressIntegrationTests.cs
+++ b/AddressesAPI.Tests/V1/E2ETests/SearchAddressIntegrationTests.cs
@@ -76,12 +76,12 @@ namespace AddressesAPI.Tests.V1.E2ETests
             var queryParameters = new NationalAddress
             {
                 USRN = _faker.Random.Int(),
-                AddressStatus = "Historical"
+                AddressStatus = "Historic"
             };
             TestEfDataHelper.InsertAddress(DatabaseContext, addressKey, queryParameters);
             AddSomeRandomAddressToTheDatabase();
 
-            var queryString = $"USRN={queryParameters.USRN}&AddressStatus=Historical&Format=Detailed";
+            var queryString = $"USRN={queryParameters.USRN}&AddressStatus=Historic&Format=Detailed";
 
             var response = await CallEndpointWithQueryParameters(queryString).ConfigureAwait(true);
             response.StatusCode.Should().Be(200);
@@ -104,11 +104,11 @@ namespace AddressesAPI.Tests.V1.E2ETests
                 Line4 = _faker.Address.Country(),
                 Town = _faker.Address.City(),
                 Postcode = "E41JJ",
-                AddressStatus = "Historical"
+                AddressStatus = "Historic"
             };
             TestEfDataHelper.InsertAddress(DatabaseContext, addressKey, addressDetails);
             AddSomeRandomAddressToTheDatabase();
-            var queryString = $"UPRN={addressDetails.UPRN}&AddressStatus=Historical&Format=Simple";
+            var queryString = $"UPRN={addressDetails.UPRN}&AddressStatus=Historic&Format=Simple";
 
             var response = await CallEndpointWithQueryParameters(queryString).ConfigureAwait(true);
             response.StatusCode.Should().Be(200);

--- a/AddressesAPI.Tests/V1/Gateways/AddressGatewayTest.cs
+++ b/AddressesAPI.Tests/V1/Gateways/AddressGatewayTest.cs
@@ -173,13 +173,13 @@ namespace AddressesAPI.Tests.V1.Gateways
 
         [TestCase("Alternative", "Alternative")]
         [TestCase("Approved Preferred", "Approved Preferred")]
-        [TestCase("Historical", "Historical")]
+        [TestCase("Historic", "Historic")]
         [TestCase("Provisional", "Provisional")]
         [TestCase("Alternative", "Alternative,Approved Preferred")]
         [TestCase("alternative", "Alternative,Approved Preferred")]
-        [TestCase("Historical", "Alternative,Approved Preferred,Historical")]
-        [TestCase("Provisional", "Historical,Provisional")]
-        [TestCase("Provisional", "Historical,provisional")]
+        [TestCase("Historic", "Alternative,Approved Preferred,Historic")]
+        [TestCase("Provisional", "Historic,Provisional")]
+        [TestCase("Provisional", "Historic,provisional")]
         public void WillSearchForAddressesWithStatus(string savedStatus, string statusSearchTerm)
         {
             var savedAddress = TestEfDataHelper.InsertAddress(DatabaseContext,
@@ -209,7 +209,7 @@ namespace AddressesAPI.Tests.V1.Gateways
         {
             var savedAddress = TestEfDataHelper.InsertAddress(DatabaseContext);
 
-            TestEfDataHelper.InsertAddress(DatabaseContext, request: new NationalAddress { AddressStatus = "Historical" });
+            TestEfDataHelper.InsertAddress(DatabaseContext, request: new NationalAddress { AddressStatus = "Historic" });
             var request = new SearchParameters
             {
                 Page = 1,

--- a/AddressesAPI.Tests/V1/UseCase/SearchAddressValidatorTests.cs
+++ b/AddressesAPI.Tests/V1/UseCase/SearchAddressValidatorTests.cs
@@ -32,8 +32,8 @@ namespace AddressesAPI.Tests.V1.UseCase
         }
 
         [TestCase("alternative")]
-        [TestCase("historical")]
-        [TestCase("approved preferred,historical")]
+        [TestCase("historic")]
+        [TestCase("approved preferred,historic")]
         public void GivenAnAllowedAddressStatusValue_WhenCallingValidation_ItReturnsNoErrors(string addressStatusVal)
         {
             var request = new SearchAddressRequest { AddressStatus = addressStatusVal };

--- a/AddressesAPI.Tests/V2/E2ETests/SearchAddressIntegrationTests.cs
+++ b/AddressesAPI.Tests/V2/E2ETests/SearchAddressIntegrationTests.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Linq;
-using System.Net.Http;
-using System.Threading.Tasks;
 using AddressesAPI.Infrastructure;
 using AddressesAPI.Tests.V2.Helper;
 using AddressesAPI.V2.Boundary.Responses.Data;
@@ -10,6 +6,10 @@ using AutoFixture;
 using Bogus;
 using FluentAssertions;
 using NUnit.Framework;
+using System;
+using System.Linq;
+using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace AddressesAPI.Tests.V2.E2ETests
 {
@@ -77,13 +77,13 @@ namespace AddressesAPI.Tests.V2.E2ETests
             var queryParameters = new NationalAddress
             {
                 USRN = _faker.Random.Int(),
-                AddressStatus = "Historical"
+                AddressStatus = "Historic"
             };
             await TestDataHelper.InsertAddressInDbAndEs(DatabaseContext, ElasticsearchClient, addressKey, queryParameters)
                 .ConfigureAwait(true);
             await AddSomeRandomAddressToTheDatabase().ConfigureAwait(true);
 
-            var queryString = $"USRN={queryParameters.USRN}&address_status=Historical&Format=Detailed&address_scope=national";
+            var queryString = $"USRN={queryParameters.USRN}&address_status=Historic&Format=Detailed&address_scope=national";
 
             var response = await CallEndpointWithQueryParameters(queryString).ConfigureAwait(true);
             response.StatusCode.Should().Be(200);
@@ -165,12 +165,12 @@ namespace AddressesAPI.Tests.V2.E2ETests
                 Line4 = _faker.Address.Country(),
                 Town = _faker.Address.City(),
                 Postcode = "E41JJ",
-                AddressStatus = "Historical"
+                AddressStatus = "Historic"
             };
             await TestDataHelper.InsertAddressInDbAndEs(DatabaseContext, ElasticsearchClient, addressKey, addressDetails)
                 .ConfigureAwait(true);
             await AddSomeRandomAddressToTheDatabase().ConfigureAwait(true);
-            var queryString = $"uprn={addressDetails.UPRN}&address_status=Historical&format=Simple&address_scope=national";
+            var queryString = $"uprn={addressDetails.UPRN}&address_status=Historic&format=Simple&address_scope=national";
 
             var response = await CallEndpointWithQueryParameters(queryString).ConfigureAwait(true);
             response.StatusCode.Should().Be(200);

--- a/AddressesAPI.Tests/V2/Gateways/SearchAddressesGatewayTest.cs
+++ b/AddressesAPI.Tests/V2/Gateways/SearchAddressesGatewayTest.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using AddressesAPI.Infrastructure;
 using AddressesAPI.Tests.V2.Helper;
 using AddressesAPI.V2;
@@ -9,8 +5,11 @@ using AddressesAPI.V2.Domain;
 using AddressesAPI.V2.Gateways;
 using Bogus;
 using FluentAssertions;
-using Nest;
 using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace AddressesAPI.Tests.V2.Gateways
 {
@@ -284,13 +283,13 @@ namespace AddressesAPI.Tests.V2.Gateways
         [TestCase("Alternative", new[] { "Alternative" })]
         [TestCase("Approved", new[] { "Approved" })]
         [TestCase("Approved Preferred", new[] { "Approved" })]
-        [TestCase("Historical", new[] { "Historical" })]
+        [TestCase("Historic", new[] { "Historic" })]
         [TestCase("Provisional", new[] { "Provisional" })]
         [TestCase("Alternative", new[] { "Alternative", "Approved" })]
         [TestCase("alternative", new[] { "Alternative", "Approved" })]
-        [TestCase("Historical", new[] { "Alternative", "Approved", "Historical" })]
-        [TestCase("Provisional", new[] { "Historical", "Provisional" })]
-        [TestCase("Provisional", new[] { "Historical", "provisional" })]
+        [TestCase("Historic", new[] { "Alternative", "Approved", "Historic" })]
+        [TestCase("Provisional", new[] { "Historic", "Provisional" })]
+        [TestCase("Provisional", new[] { "Historic", "provisional" })]
         public async Task WillSearchForAddressesWithStatus(string savedStatus, IEnumerable<string> statusSearchTerm)
         {
             var savedAddress = await TestDataHelper.InsertAddressInEs(ElasticsearchClient,
@@ -320,7 +319,7 @@ namespace AddressesAPI.Tests.V2.Gateways
             var savedAddress = await TestDataHelper.InsertAddressInEs(ElasticsearchClient).ConfigureAwait(true);
 
             await TestDataHelper.InsertAddressInEs(ElasticsearchClient,
-                addressConfig: new QueryableAddress { AddressStatus = "Historical" }).ConfigureAwait(true);
+                addressConfig: new QueryableAddress { AddressStatus = "Historic" }).ConfigureAwait(true);
             var request = new SearchParameters
             {
                 Page = 1,

--- a/AddressesAPI.Tests/V2/UseCase/GetSingleAddressUseCaseTest.cs
+++ b/AddressesAPI.Tests/V2/UseCase/GetSingleAddressUseCaseTest.cs
@@ -1,4 +1,3 @@
-using System;
 using AddressesAPI.Tests.V2.Helper;
 using AddressesAPI.V2.Boundary.Requests;
 using AddressesAPI.V2.Boundary.Responses;
@@ -11,6 +10,7 @@ using FluentAssertions;
 using FluentValidation.Results;
 using Moq;
 using NUnit.Framework;
+using System;
 
 namespace AddressesAPI.Tests.V2.UseCase
 {
@@ -82,7 +82,7 @@ namespace AddressesAPI.Tests.V2.UseCase
                 UPRN = 10024389298,
                 USRN = 21320239,
                 ParentUPRN = 10024389282,
-                AddressStatus = "Historical",
+                AddressStatus = "Historic",
                 UnitName = "FLAT 16",
                 UnitNumber = "",
                 BuildingName = "HAZELNUT COURT",

--- a/AddressesAPI.Tests/V2/UseCase/SearchAddressUseCaseTest.cs
+++ b/AddressesAPI.Tests/V2/UseCase/SearchAddressUseCaseTest.cs
@@ -1,7 +1,3 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using AddressesAPI.V2;
 using AddressesAPI.V2.Boundary.Requests;
 using AddressesAPI.V2.Boundary.Responses;
@@ -16,6 +12,10 @@ using Bogus;
 using FluentAssertions;
 using Moq;
 using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 using ValidationResult = FluentValidation.Results.ValidationResult;
 
 namespace AddressesAPI.Tests.V2.UseCase
@@ -109,7 +109,7 @@ namespace AddressesAPI.Tests.V2.UseCase
             _addressGateway.Verify();
         }
 
-        [TestCase("approved,historical", new[] { "approved", "historical" })]
+        [TestCase("approved,historic", new[] { "approved", "historic" })]
         [TestCase("provisional", new[] { "provisional" })]
         public void ExecuteAsync_CorrectlyConvertsAddressStatusIntoAList(string addressQuery, IEnumerable<string> expectedList)
         {

--- a/AddressesAPI.Tests/V2/UseCase/SearchAddressValidatorTests.cs
+++ b/AddressesAPI.Tests/V2/UseCase/SearchAddressValidatorTests.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using AddressesAPI.V2;
 using AddressesAPI.V2.Boundary.Requests;
 using AddressesAPI.V2.UseCase;
@@ -6,6 +5,7 @@ using Bogus;
 using FluentAssertions;
 using FluentValidation.TestHelper;
 using NUnit.Framework;
+using System.Collections.Generic;
 
 namespace AddressesAPI.Tests.V2.UseCase
 {
@@ -36,8 +36,8 @@ namespace AddressesAPI.Tests.V2.UseCase
         }
 
         [TestCase("alternative")]
-        [TestCase("historical")]
-        [TestCase("approved,historical")]
+        [TestCase("historic")]
+        [TestCase("approved,historic")]
         public void GivenAnAllowedAddressStatusValue_WhenCallingValidation_ItReturnsNoErrors(string addressStatusVal)
         {
             var request = new SearchAddressRequest { AddressStatus = addressStatusVal };

--- a/AddressesAPI/V1/Boundary/Requests/SearchAddressRequest.cs
+++ b/AddressesAPI/V1/Boundary/Requests/SearchAddressRequest.cs
@@ -93,7 +93,7 @@ namespace AddressesAPI.V1.Boundary.Requests
         /// Allows switch between address statuses:
         /// Alternative,
         /// Approved Preferred (Default),
-        /// Historical,
+        /// Historic,
         /// Provisional
         /// </summary>
         public string AddressStatus { get; set; }

--- a/AddressesAPI/V1/Boundary/Responses/Data/AddressResponse.cs
+++ b/AddressesAPI/V1/Boundary/Responses/Data/AddressResponse.cs
@@ -31,7 +31,7 @@ namespace AddressesAPI.V1.Boundary.Responses.Data
         /// <summary>
         /// Only included if format query parameter is set to detailed.
         /// </summary>
-        public string AddressStatus { get; set; } //1 = "Approved Preferred", 3 = "Alternative", 5 = "Candidate", 6 = "Provisional", 7 = "Rejected External",  8 = "Historical", 9 = "Rejected Internal"
+        public string AddressStatus { get; set; } //1 = "Approved Preferred", 3 = "Alternative", 5 = "Candidate", 6 = "Provisional", 7 = "Rejected External",  8 = "Historic", 9 = "Rejected Internal"
         /// <summary>
         /// Only included if format query parameter is set to detailed.
         /// </summary>

--- a/AddressesAPI/V1/Domain/Address.cs
+++ b/AddressesAPI/V1/Domain/Address.cs
@@ -8,7 +8,7 @@ namespace AddressesAPI.V1.Domain
         public string AddressKey { get; set; }
         public int? USRN { get; set; }
         public long? ParentUPRN { get; set; } //nullable
-        public string AddressStatus { get; set; } //1 = "Approved", 3 = "Alternative", 5 = "Candidate", 6 = "Provisional", 7 = "Rejected External",  8 = "Historical", 9 = "Rejected Internal"
+        public string AddressStatus { get; set; } //1 = "Approved", 3 = "Alternative", 5 = "Candidate", 6 = "Provisional", 7 = "Rejected External",  8 = "Historic", 9 = "Rejected Internal"
         public string UnitName { get; set; }
         public string UnitNumber { get; set; } //string because can be e.g. "1a"
         public string BuildingName { get; set; }

--- a/AddressesAPI/V1/UseCase/SearchAddressValidator.cs
+++ b/AddressesAPI/V1/UseCase/SearchAddressValidator.cs
@@ -85,7 +85,7 @@ namespace AddressesAPI.V1.UseCase
 
         private static bool CanBeAnyCombinationOfAllowedAddressStatuses(string addressStatus)
         {
-            var allowedValues = new List<string> { "historical", "alternative", "approved preferred", "provisional" };
+            var allowedValues = new List<string> { "historic", "alternative", "approved preferred", "provisional" };
             if (string.IsNullOrEmpty(addressStatus))
             {
                 return false;

--- a/AddressesAPI/V2/Boundary/Requests/SearchAddressRequest.cs
+++ b/AddressesAPI/V2/Boundary/Requests/SearchAddressRequest.cs
@@ -1,5 +1,5 @@
-using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
 
 namespace AddressesAPI.V2.Boundary.Requests
 {
@@ -83,7 +83,7 @@ namespace AddressesAPI.V2.Boundary.Requests
         /// Allows switch between address statuses:
         /// Alternative,
         /// Approved (Default),
-        /// Historical,
+        /// Historic,
         /// Provisional
         /// </summary>
         [FromQuery(Name = "address_status")]

--- a/AddressesAPI/V2/Boundary/Responses/Data/AddressResponse.cs
+++ b/AddressesAPI/V2/Boundary/Responses/Data/AddressResponse.cs
@@ -59,7 +59,7 @@ namespace AddressesAPI.V2.Boundary.Responses.Data
         /// <summary>
         /// Only included if format query parameter is set to detailed.
         /// </summary>
-        public string AddressStatus { get; set; } //1 = "Approved", 3 = "Alternative", 5 = "Candidate", 6 = "Provisional", 7 = "Rejected External",  8 = "Historical", 9 = "Rejected Internal"
+        public string AddressStatus { get; set; } //1 = "Approved", 3 = "Alternative", 5 = "Candidate", 6 = "Provisional", 7 = "Rejected External",  8 = "Historic", 9 = "Rejected Internal"
         /// <summary>
         /// Only included if format query parameter is set to detailed.
         /// </summary>

--- a/AddressesAPI/V2/Domain/Address.cs
+++ b/AddressesAPI/V2/Domain/Address.cs
@@ -6,7 +6,7 @@ namespace AddressesAPI.V2.Domain
         public string AddressKey { get; set; }
         public int? USRN { get; set; }
         public long? ParentUPRN { get; set; } //nullable
-        public string AddressStatus { get; set; } //1 = "Approved", 3 = "Alternative", 5 = "Candidate", 6 = "Provisional", 7 = "Rejected External",  8 = "Historical", 9 = "Rejected Internal"
+        public string AddressStatus { get; set; } //1 = "Approved", 3 = "Alternative", 5 = "Candidate", 6 = "Provisional", 7 = "Rejected External",  8 = "Historic", 9 = "Rejected Internal"
         public string UnitName { get; set; }
         public string UnitNumber { get; set; } //string because can be e.g. "1a"
         public string BuildingName { get; set; }

--- a/AddressesAPI/V2/UseCase/SearchAddressValidator.cs
+++ b/AddressesAPI/V2/UseCase/SearchAddressValidator.cs
@@ -1,11 +1,11 @@
+using AddressesAPI.V2.Boundary.Requests;
+using AddressesAPI.V2.UseCase.Interfaces;
+using FluentValidation;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
-using AddressesAPI.V2.Boundary.Requests;
-using AddressesAPI.V2.UseCase.Interfaces;
-using FluentValidation;
 
 namespace AddressesAPI.V2.UseCase
 {
@@ -116,7 +116,7 @@ namespace AddressesAPI.V2.UseCase
 
         private static bool CanBeAnyCombinationOfAllowedAddressStatuses(string addressStatus)
         {
-            var allowedValues = new List<string> { "historical", "alternative", "approved", "provisional" };
+            var allowedValues = new List<string> { "historic", "alternative", "approved", "provisional" };
             if (string.IsNullOrEmpty(addressStatus))
             {
                 return false;


### PR DESCRIPTION
## Link to JIRA ticket

N/A

## Describe this PR

### *What is the problem we're trying to solve*

Data & Insight team would like to query historical addresses, but the conflict between the values in the database and the query validation used against the values means they don't get the correct results back.

### *What changes have we introduced*

The correct `lpi_logical_status` for historical addressess is `historic` and not `historical` like the API has been setup to use. This means any queries run againts historical records return no results.

This update renames the status to use the correct one and changes the validation accordingly.

Historical addressess are not typically used by any clients outside the D&I team, so the breaking validation change can be handled in the scope of D&I clients. D&I team has also confirmed that `historical` is not a valid value for the status and therefore should not be supported.

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Ask D&I team to run queries against historical records to ensure they are now returning correctly.
