### PR TITLE
TS-1963 Add support for searching by parent uprn

### DIFF
--- a/AddressesAPI.Tests/V1/E2ETests/SearchAddressIntegrationTests.cs
+++ b/AddressesAPI.Tests/V1/E2ETests/SearchAddressIntegrationTests.cs
@@ -157,8 +157,8 @@ namespace AddressesAPI.Tests.V1.E2ETests
 
         [TestCase("PageSize=100", "PageSize", "PageSize cannot exceed 50")]
         [TestCase("PostCode=12376", "PostCode", "Must provide at least the first part of the postcode.")]
-        [TestCase("Gazetteer=Both&street=hackneyroad", "", "You must provide at least one of (uprn, usrn, postcode), when gazetteer is 'both'.")]
-        [TestCase("Gazetteer=Local", "", "You must provide at least one of (uprn, usrn, postcode, street, usagePrimary, usageCode), when gazeteer is 'local'.")]
+        [TestCase("Gazetteer=Both&street=hackneyroad", "", "You must provide at least one of (uprn, parentUprn, usrn, postcode), when gazetteer is 'both'.")]
+        [TestCase("Gazetteer=Local", "", "You must provide at least one of (uprn, parentUprn, usrn, postcode, street, usagePrimary, usageCode), when gazeteer is 'local'.")]
         public async Task ValidationErrors(string queryString, string fieldName, string message)
         {
             var response = await CallEndpointWithQueryParameters(queryString).ConfigureAwait(true);

--- a/AddressesAPI.Tests/V1/UseCase/SearchAddressValidatorTests.cs
+++ b/AddressesAPI.Tests/V1/UseCase/SearchAddressValidatorTests.cs
@@ -271,7 +271,6 @@ namespace AddressesAPI.Tests.V1.UseCase
             _classUnderTest.TestValidate(request).ShouldNotHaveError();
         }
 
-
         [TestCase(12345)]
         public void GivenARequestWithOnlyParentUPRN_IfGazetteerIsBoth_WhenCallingValidation_ItReturnsNoError(int uprn)
         {

--- a/AddressesAPI.Tests/V1/UseCase/SearchAddressValidatorTests.cs
+++ b/AddressesAPI.Tests/V1/UseCase/SearchAddressValidatorTests.cs
@@ -317,7 +317,7 @@ namespace AddressesAPI.Tests.V1.UseCase
         public void GivenARequestWithOnlyAStreet_IfGazetteerIsBoth_WhenCallingValidation_ItReturnsAnError(string street)
         {
             var request = new SearchAddressRequest() { Street = street };
-            _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage("You must provide at least one of (uprn, usrn, postcode), when gazetteer is 'both'.");
+            _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage("You must provide at least one of (uprn, parentUprn, usrn, postcode), when gazetteer is 'both'.");
         }
 
         [TestCase("someValue")]
@@ -331,7 +331,7 @@ namespace AddressesAPI.Tests.V1.UseCase
         public void GivenARequestWithOnlyUsagePrimary_IfGazetteerIsBoth_WhenCallingValidation_ItReturnsAnError(string usagePrimary)
         {
             var request = new SearchAddressRequest() { usagePrimary = usagePrimary };
-            _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage("You must provide at least one of (uprn, usrn, postcode), when gazetteer is 'both'.");
+            _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage("You must provide at least one of (uprn, parentUprn, usrn, postcode), when gazetteer is 'both'.");
         }
 
         [TestCase("otherValue")]
@@ -345,21 +345,21 @@ namespace AddressesAPI.Tests.V1.UseCase
         public void GivenARequestWithOnlyUsageCode_IfGazetteerIsBoth_WhenCallingValidation_ItReturnsAnError(string usageCode)
         {
             var request = new SearchAddressRequest() { usageCode = usageCode };
-            _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage("You must provide at least one of (uprn, usrn, postcode), when gazetteer is 'both'.");
+            _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage("You must provide at least one of (uprn, parentUprn, usrn, postcode), when gazetteer is 'both'.");
         }
 
         [TestCase("12345")]
         public void GivenARequestWithNoMandatoryFields_IfGazetteerIsLocal_WhenCallingValidation_ItReturnsAnError(string buildingNumber)
         {
             var request = new SearchAddressRequest() { BuildingNumber = buildingNumber, Gazetteer = _localGazetteer };
-            _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage("You must provide at least one of (uprn, usrn, postcode, street, usagePrimary, usageCode), when gazeteer is 'local'.");
+            _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage("You must provide at least one of (uprn, parentUprn, usrn, postcode, street, usagePrimary, usageCode), when gazeteer is 'local'.");
         }
 
         [TestCase("12345")]
         public void GivenARequestWithNoMandatoryFields_IfGazetteerIsBoth_WhenCallingValidation_ItReturnsAnError(string buildingNumber)
         {
             var request = new SearchAddressRequest() { BuildingNumber = buildingNumber };
-            _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage("You must provide at least one of (uprn, usrn, postcode), when gazetteer is 'both'.");
+            _classUnderTest.TestValidate(request).ShouldHaveError().WithErrorMessage("You must provide at least one of (uprn, parentUprn, usrn, postcode), when gazetteer is 'both'.");
         }
 
         [Test]

--- a/AddressesAPI.Tests/V1/UseCase/SearchAddressValidatorTests.cs
+++ b/AddressesAPI.Tests/V1/UseCase/SearchAddressValidatorTests.cs
@@ -265,6 +265,21 @@ namespace AddressesAPI.Tests.V1.UseCase
         }
 
         [TestCase(12345)]
+        public void GivenARequestWithOnlyParentUPRN_IfGazetteerIsLocal_WhenCallingValidation_ItReturnsNoError(int uprn)
+        {
+            var request = new SearchAddressRequest() { ParentUPRN = uprn, Gazetteer = _localGazetteer };
+            _classUnderTest.TestValidate(request).ShouldNotHaveError();
+        }
+
+
+        [TestCase(12345)]
+        public void GivenARequestWithOnlyParentUPRN_IfGazetteerIsBoth_WhenCallingValidation_ItReturnsNoError(int uprn)
+        {
+            var request = new SearchAddressRequest() { ParentUPRN = uprn };
+            _classUnderTest.TestValidate(request).ShouldNotHaveError();
+        }
+
+        [TestCase(12345)]
         public void GivenARequestWithOnlyUSRN_IfGazetteerIsLocal_WhenCallingValidation_ItReturnsNoError(int usrn)
         {
             var request = new SearchAddressRequest() { USRN = usrn, Gazetteer = _localGazetteer };

--- a/AddressesAPI/V1/Boundary/Requests/SearchAddressRequest.cs
+++ b/AddressesAPI/V1/Boundary/Requests/SearchAddressRequest.cs
@@ -60,6 +60,11 @@ namespace AddressesAPI.V1.Boundary.Requests
         public long? UPRN { get; set; }
 
         /// <summary>
+        /// Filter by parent UPRN
+        /// </summary>
+        public long? ParentUPRN { get; set; }
+
+        /// <summary>
         /// Filter by USRN (unique street reference number - uniquely identifies streets)
         /// </summary>
         public int? USRN { get; set; }

--- a/AddressesAPI/V1/UseCase/SearchAddressUseCase.cs
+++ b/AddressesAPI/V1/UseCase/SearchAddressUseCase.cs
@@ -54,6 +54,7 @@ namespace AddressesAPI.V1.UseCase
                 Postcode = request.PostCode,
                 Street = request.Street,
                 Uprn = request.UPRN,
+                ParentUprn = request.ParentUPRN,
                 Usrn = request.USRN,
                 AddressStatus = request.AddressStatus,
                 BuildingNumber = request.BuildingNumber,

--- a/AddressesAPI/V1/UseCase/SearchAddressValidator.cs
+++ b/AddressesAPI/V1/UseCase/SearchAddressValidator.cs
@@ -35,11 +35,11 @@ namespace AddressesAPI.V1.UseCase
 
             RuleFor(r => r)
                 .Must(CheckForAtLeastOneMandatoryFilterPropertyWithGazetteerLocal)
-                .WithMessage("You must provide at least one of (uprn, usrn, postcode, street, usagePrimary, usageCode), when gazeteer is 'local'.");
+                .WithMessage("You must provide at least one of (uprn, parentUprn, usrn, postcode, street, usagePrimary, usageCode), when gazeteer is 'local'.");
 
             RuleFor(r => r)
                 .Must(CheckForAtLeastOneMandatoryFilterPropertyWithGazetteerBoth)
-                .WithMessage("You must provide at least one of (uprn, usrn, postcode), when gazetteer is 'both'.");
+                .WithMessage("You must provide at least one of (uprn, parentUprn, usrn, postcode), when gazetteer is 'both'.");
 
             RuleFor(r => r.RequestFields)
                 .Must(CheckForInvalidProperties)
@@ -68,6 +68,7 @@ namespace AddressesAPI.V1.UseCase
         {
             return request.Gazetteer == GlobalConstants.Gazetteer.Both.ToString()
                    || request.UPRN != null
+                   || request.ParentUPRN != null
                    || request.USRN != null
                    || request.PostCode != null
                    || request.Street != null
@@ -79,6 +80,7 @@ namespace AddressesAPI.V1.UseCase
         {
             return request.Gazetteer != GlobalConstants.Gazetteer.Both.ToString()
                    || request.UPRN != null
+                   || request.ParentUPRN != null
                    || request.USRN != null
                    || request.PostCode != null;
         }


### PR DESCRIPTION
## Link to JIRA ticket

[TS-1963](https://hackney.atlassian.net/browse/TS-1963)

## Describe this PR

### *What is the problem we're trying to solve*

In Temporary Accommodation we need to be able to search addresses by parent UPRN. This enables us to fetch addresses that belong to a given parent address i.e. block by using the block's UPRN.

### *What changes have we introduced*

1. Add new `ParentUPRN ` query string parameter
2. Update the `SearchAddressValidator` to allow searching by parent UPRN only in the same way as by UPRN only

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

N/A
