### PR TITLE
Split code deployment and terraform workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,22 +260,6 @@ workflows:
           filters:
             branches:
               only: master
-      - preview-terraform-staging-changes:
-          requires:
-            - assume-role-staging
-          filters:
-            branches:
-              only: master
-      - continue-with-staging-terraform-release:
-          type: approval
-          requires:
-            - preview-terraform-staging-changes
-      - terraform-init-and-apply-to-staging:
-          requires:
-            - continue-with-staging-terraform-release
-          filters:
-            branches:
-              only: master
       # - migrate-database-staging:
       #     requires:
       #       - terraform-init-and-apply-to-staging
@@ -290,14 +274,86 @@ workflows:
           filters:
             branches:
               only: master
-      - permit-production-terraform-release:
+      - permit-production-deployment-workflow:
           type: approval
           requires:
             - deploy-to-staging
+          filters:
+            branches:
+              only: master
       - assume-role-production:
           context: api-assume-role-production-context
           requires:
-              - permit-production-terraform-release
+              - permit-production-deployment-workflow
+          filters:
+             branches:
+               only: master
+      # - migrate-database-production:
+      #     requires:
+      #       - terraform-init-and-apply-to-production
+      #       - assume-role-production
+      #     filters:
+      #       branches:
+      #         only: master
+      - permit-production-release:
+          type: approval
+          requires:
+            - assume-role-production
+          filters:
+            branches:
+              only: master
+      - deploy-to-production:
+          context: "Serverless Framework"
+          requires:
+            - permit-production-release
+          filters:
+            branches:
+              only: master
+
+  deploy-staging-and-production-terraform:
+    jobs:
+      - permit-staging-and-production-terraform-workflow:
+          type: approval
+          filters:
+            branches:
+              only: master
+      - assume-role-staging:
+          context: api-assume-role-staging-context
+          requires:
+            - permit-staging-and-production-terraform-workflow
+          filters:
+            branches:
+              only: master
+      - preview-terraform-staging-changes:
+          requires:
+            - assume-role-staging
+          filters:
+            branches:
+              only: master
+      - continue-with-staging-terraform-release:
+          type: approval
+          requires:
+            - preview-terraform-staging-changes
+          filters:
+            branches:
+              only: master
+      - terraform-init-and-apply-to-staging:
+          requires:
+            - continue-with-staging-terraform-release
+          filters:
+            branches:
+              only: master      
+      - permit-production-terraform-workflow:
+          type: approval
+          requires:
+            - terraform-init-and-apply-to-staging
+          filters:
+            branches:
+              only: master
+      - assume-role-production:
+          context: api-assume-role-production-context
+          requires:
+              - permit-production-terraform-workflow
           filters:
              branches:
                only: master
@@ -311,31 +367,12 @@ workflows:
             type: approval
             requires:
               - preview-terraform-production-changes
+            filters:
+              branches:
+                only: master
       - terraform-init-and-apply-to-production:
           requires:
             - continue-with-production-terraform-release
-          filters:
-            branches:
-              only: master
-      # - migrate-database-production:
-      #     requires:
-      #       - terraform-init-and-apply-to-production
-      #       - assume-role-production
-      #     filters:
-      #       branches:
-      #         only: master
-      - permit-production-release:
-          type: approval
-          requires:
-            - deploy-to-staging
-          filters:
-            branches:
-              only: master
-      - deploy-to-production:
-          context: "Serverless Framework"
-          requires:
-            - permit-production-release
-            - assume-role-production
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,17 +295,10 @@ workflows:
       #     filters:
       #       branches:
       #         only: master
-      - permit-production-release:
-          type: approval
-          requires:
-            - assume-role-production
-          filters:
-            branches:
-              only: master
       - deploy-to-production:
           context: "Serverless Framework"
           requires:
-            - permit-production-release
+            - assume-role-production
           filters:
             branches:
               only: master


### PR DESCRIPTION
This update splits the code and terraform deployment workflows, so they can be run independently.

Configuration can be further improved by using the Terraform plan output in the approval step. Also all references to non existent development environment can be removed.  