### PR TITLE
Fix API key

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -22,7 +22,7 @@ functions:
       - http:
           path: /{proxy+}
           method: ANY
-          private: true
+          private: false
           cors: true
           authorizer:
             arn: ${self:custom.authorizerArns.${opt:stage}}


### PR DESCRIPTION
The service requires an API key on staging due to the `private` field but not on prod

Switch it off to match prod which is expected fix the auth issue in staging