### PR TITLE
Deploy DMS staging replication instance

### DIFF
--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -156,6 +156,16 @@ resource "aws_iam_role_policy_attachment" "attach_policy" {
   policy_arn = aws_iam_policy.es_policy.arn
 }
 
+module "dms_replication_instance_staging" {
+  source = "./modules/dms"
+  environment_name = "staging"
+  project_name = "addresses-api"
+  replication_instance_identifier = "staging-dms-instance"
+  replication_instance_class = "dms.t3.small"
+  vpc_id = data.aws_vpc.staging_vpc.id
+  subnet_ids = data.aws_subnet_ids.staging.ids
+  maintenance_window = "Sun:08:00-Sun:08:30"
+}
 resource "aws_dms_endpoint" "address_elasticsearch" {
   endpoint_id   = "target-addresses-es"
   endpoint_type = "target"

--- a/terraform/staging/modules/dms/main.tf
+++ b/terraform/staging/modules/dms/main.tf
@@ -1,0 +1,39 @@
+module "dms_replication_instance_sg" {
+  source = "../security_groups/dms"
+  environment_name = "staging"
+  vpc_id = var.vpc_id
+}
+
+resource "aws_dms_replication_subnet_group" "dms_subnet_group" {
+  replication_subnet_group_description = "Replication subnet group for ${var.project_name}"
+  replication_subnet_group_id          = "dms-replication-subnet-group-${var.replication_instance_identifier}"
+
+  subnet_ids = var.subnet_ids
+
+
+  tags = {
+    Environment = var.environment_name,
+    project_name = var.project_name
+  }
+}
+
+resource "aws_dms_replication_instance" "address_dms_rep_instance" {
+  replication_instance_class = var.replication_instance_class
+  replication_instance_id    = var.replication_instance_identifier
+  replication_subnet_group_id = aws_dms_replication_subnet_group.dms_subnet_group.id
+  engine_version = "3.5.3"
+  auto_minor_version_upgrade = false
+  publicly_accessible = false
+  allocated_storage = 20
+  availability_zone = "eu-west-2a"
+  multi_az = false
+  apply_immediately = true
+
+  tags = {
+    Name = var.replication_instance_identifier
+    Environment = var.environment_name
+    project_name = var.project_name
+  }
+
+  vpc_security_group_ids = [module.dms_replication_instance_sg.dms_sg_id]
+}

--- a/terraform/staging/modules/dms/variables.tf
+++ b/terraform/staging/modules/dms/variables.tf
@@ -1,0 +1,33 @@
+variable "environment_name" {
+  type = string
+}
+
+variable "project_name" {
+  type = string
+}
+
+variable "replication_instance_class" {
+  type = string //e.g. "dms.t2.small"
+}
+
+variable "replication_instance_identifier" {
+  type = string
+}
+
+variable "maintenance_window" {
+  type = string //e.g. "tue:10:00-tue:10:30"
+}
+
+variable "subnet_ids" {
+  type = list(string)
+}
+
+variable "vpc_security_group_ids" {
+  description = "A list of security group IDs to associate with"
+  type        = list(string)
+  default     = null
+}
+
+variable "vpc_id" {
+  type = string
+}

--- a/terraform/staging/modules/security_groups/dms/main.tf
+++ b/terraform/staging/modules/security_groups/dms/main.tf
@@ -1,0 +1,24 @@
+resource "aws_security_group" "dms_sg" {
+  name        = "dms-instance-${var.environment_name}"
+  description = "Allow self traffic for DMS security group"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description = "DMS traffic"
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    self = true
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "dms-instance-${var.environment_name}-sg"
+  }
+}

--- a/terraform/staging/modules/security_groups/dms/outputs.tf
+++ b/terraform/staging/modules/security_groups/dms/outputs.tf
@@ -1,0 +1,3 @@
+output "dms_sg_id" {
+  value = aws_security_group.dms_sg.id
+}

--- a/terraform/staging/modules/security_groups/dms/variables.tf
+++ b/terraform/staging/modules/security_groups/dms/variables.tf
@@ -1,0 +1,7 @@
+variable "vpc_id" {
+  type = string
+}
+
+variable "environment_name" {
+  type = string
+}

--- a/terraform/staging/selection_rules_local.json
+++ b/terraform/staging/selection_rules_local.json
@@ -1,0 +1,122 @@
+{
+  "rules": [
+    {
+      "rule-type": "selection",
+      "rule-id": "1",
+      "rule-name": "1",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "hackney_address"
+      },
+      "rule-action": "include"
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "3",
+      "rule-name": "3",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "hackney_address",
+        "column-name": "postcode_nospace"
+      }
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "5",
+      "rule-name": "5",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "hackney_address",
+        "column-name": "organisation"
+      }
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "7",
+      "rule-name": "7",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "hackney_address",
+        "column-name": "latitude"
+      }
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "9",
+      "rule-name": "9",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "hackney_address",
+        "column-name": "longitude"
+      }
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "11",
+      "rule-name": "11",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "hackney_address",
+        "column-name": "planning_use_class"
+      }
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "13",
+      "rule-name": "13",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "hackney_address",
+        "column-name": "ward"
+      }
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "15",
+      "rule-name": "15",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "hackney_address",
+        "column-name": "locality"
+      }
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "17",
+      "rule-name": "17",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "hackney_address",
+        "column-name": "northing"
+      }
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "19",
+      "rule-name": "19",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "hackney_address",
+        "column-name": "easting"
+      }
+    }
+  ]
+}

--- a/terraform/staging/selection_rules_national.json
+++ b/terraform/staging/selection_rules_national.json
@@ -1,0 +1,122 @@
+{
+  "rules": [
+    {
+      "rule-type": "selection",
+      "rule-id": "2",
+      "rule-name": "2",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "national_address"
+      },
+      "rule-action": "include"
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "4",
+      "rule-name": "4",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "national_address",
+        "column-name": "postcode_nospace"
+      }
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "6",
+      "rule-name": "6",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "national_address",
+        "column-name": "organisation"
+      }
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "8",
+      "rule-name": "8",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "national_address",
+        "column-name": "latitude"
+      }
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "10",
+      "rule-name": "10",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "national_address",
+        "column-name": "longitude"
+      }
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "12",
+      "rule-name": "12",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "national_address",
+        "column-name": "planning_use_class"
+      }
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "14",
+      "rule-name": "14",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "national_address",
+        "column-name": "ward"
+      }
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "16",
+      "rule-name": "16",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "national_address",
+        "column-name": "locality"
+      }
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "18",
+      "rule-name": "18",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "national_address",
+        "column-name": "northing"
+      }
+    },
+    {
+      "rule-type": "transformation",
+      "rule-id": "20",
+      "rule-name": "20",
+      "rule-action": "remove-column",
+      "rule-target": "column",
+      "object-locator": {
+        "schema-name": "%",
+        "table-name": "national_address",
+        "column-name": "easting"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### What
This PR deploys the following to set up a DMS replication instance on the staging environment:

- The DMS replication instance
- Subnet group for the instance
- Security group for the instance
- The selection rules for local and national addresses which will be applied to the replication tasks.

### Why
The replication instance is missing on the staging environment. It is used to read and format data from the postgres SQL DB which is then consumed by the elastic search. The security group rules are the same as what is on production.
### Notes
A future PR will be made to add the DMS migration tasks which are ran by the replication instance. This needs to be deployed first to get certain configuration information such as the ARN so that the tasks can be attached to the replication instance.