### PR TITLE
Use already created security group for replication instance

### DIFF
--- a/terraform/staging/modules/dms/main.tf
+++ b/terraform/staging/modules/dms/main.tf
@@ -1,8 +1,8 @@
-module "dms_replication_instance_sg" {
-  source = "../security_groups/dms"
-  environment_name = "staging"
-  vpc_id = var.vpc_id
-}
+# module "dms_replication_instance_sg" {
+#   source = "../security_groups/dms"
+#   environment_name = "staging"
+#   vpc_id = var.vpc_id
+# }
 
 resource "aws_dms_replication_subnet_group" "dms_subnet_group" {
   replication_subnet_group_description = "Replication subnet group for ${var.project_name}"
@@ -35,5 +35,5 @@ resource "aws_dms_replication_instance" "address_dms_rep_instance" {
     project_name = var.project_name
   }
 
-  vpc_security_group_ids = [module.dms_replication_instance_sg.dms_sg_id]
+  vpc_security_group_ids = ["sg-0f2b37cc9a9e2cb60"]
 }


### PR DESCRIPTION
### What
This PR adds the ID for the already created security group to DMS replication instance that will be created
### Why
Terraform does not allow you to import AWS infrastructure to child modules. As such to import the security group to terraform I will need to restructure the file structure for the staging terraform in order to eliminate the drift. Right now it is more important to get the replication instance up so that will be done in a future PR. 