### PR TITLE
Create DMS IAM role to allow creation of replication instance

### DIFF
--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -121,6 +121,16 @@ data "aws_iam_policy_document" "dms-assume-role-policy" {
   }
 }
 
+resource "aws_iam_role" "dms-vpc-role" {
+  assume_role_policy = "${data.aws_iam_policy_document.dms-assume-role-policy.json}"
+  name               = "dms-vpc-role"
+}
+
+resource "aws_iam_role_policy_attachment" "dms-vpc-role-AmazonDMSVPCManagementRole" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonDMSVPCManagementRole"
+  role       = "${aws_iam_role.dms-vpc-role.name}"
+}
+
 resource "aws_iam_role" "dms_service_role" {
   name               = "dms_service_role"
   path               = "/system/"

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -122,13 +122,13 @@ data "aws_iam_policy_document" "dms-assume-role-policy" {
 }
 
 resource "aws_iam_role" "dms-vpc-role" {
-  assume_role_policy = "${data.aws_iam_policy_document.dms-assume-role-policy.json}"
+  assume_role_policy = data.aws_iam_policy_document.dms-assume-role-policy.json
   name               = "dms-vpc-role"
 }
 
 resource "aws_iam_role_policy_attachment" "dms-vpc-role-AmazonDMSVPCManagementRole" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonDMSVPCManagementRole"
-  role       = "${aws_iam_role.dms-vpc-role.name}"
+  role       = aws_iam_role.dms-vpc-role.name
 }
 
 resource "aws_iam_role" "dms_service_role" {


### PR DESCRIPTION
### What
PR to create the IAM role with the permission`AmazonDMSVPCManagementRole`.
### Why
The aforementioned role and permission are needed to allow the creation of the DMS replication instance