### PR TITLE
Create staging DMS replication tasks

### DIFF
--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -110,6 +110,10 @@ data "aws_ssm_parameter" "addresses_elasticsearch_domain" {
 }
 
 /*    DMS SETUP    */
+data "aws_ssm_parameter" "dms_rep_instance_id" {
+  name = "/addresses-api/staging/dms-rep-instance-id"
+}
+
 data "aws_iam_policy_document" "dms-assume-role-policy" {
   statement {
     actions = ["sts:AssumeRole"]
@@ -208,4 +212,40 @@ module "source_db_endpoint" {
   project_name            = "addresses-api"
   db_username             = data.aws_ssm_parameter.addresses_postgres_username.value
   db_password             = data.aws_ssm_parameter.addresses_postgres_db_password.value
+}
+
+module "address-es-dms-local-addresses" {
+  source                       = "github.com/LBHackney-IT/aws-dms-terraform.git//dms_replication_task"
+  environment_name             = "staging"
+  project_name                 = "addresses-api"
+  migration_type               = "full-load"
+  replication_instance_arn     = "arn:aws:dms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rep:${data.aws_ssm_parameter.dms_rep_instance_id.value}"
+  replication_task_indentifier = "addresses-api-es-dms-task-local-addresses"
+  task_settings = templatefile("${path.module}/task_settings.json",
+    {
+      dms_replication_instance_name = "staging-dms-instance",
+      dms_instance_task_resource    = "" // Will be updated once the task has been deployed
+    }
+  )
+  source_endpoint_arn = module.source_db_endpoint.dms_endpoint_arn
+  target_endpoint_arn = aws_dms_endpoint.address_elasticsearch.endpoint_arn
+  task_table_mappings = file("${path.module}/selection_rules_local.json")
+}
+
+module "address-es-dms-national-addresses" {
+  source                       = "github.com/LBHackney-IT/aws-dms-terraform.git//dms_replication_task"
+  environment_name             = "staging"
+  project_name                 = "addresses-api"
+  migration_type               = "full-load-and-cdc"
+  replication_instance_arn     = "arn:aws:dms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rep:${data.aws_ssm_parameter.dms_rep_instance_id.value}"
+  replication_task_indentifier = "addresses-api-es-dms-task-national-addresses"
+  task_settings = templatefile("${path.module}/task_settings.json",
+    {
+      dms_replication_instance_name = "staging-dms-instance",
+      dms_instance_task_resource    = "" // Will be updated once the task has been deployed
+    }
+  )
+  source_endpoint_arn = module.source_db_endpoint.dms_endpoint_arn
+  target_endpoint_arn = aws_dms_endpoint.address_elasticsearch.endpoint_arn
+  task_table_mappings = file("${path.module}/selection_rules_national.json")
 }

--- a/terraform/staging/modules/dms/outputs.tf
+++ b/terraform/staging/modules/dms/outputs.tf
@@ -1,0 +1,3 @@
+output "dms_rep_instance_arn" {
+  value       = aws_dms_replication_instance.address_dms_rep_instance.replication_instance_arn                                         
+}


### PR DESCRIPTION
### What
This PR creates two DMS replication tasks. One for national addresses and another for local Hackney ones.
### Why
The replication tasks carry out the data migration of addresses data from the postgres DB to the elastic search index.
### Notes
The task settings parameter on both tasks require the ID to create the cloudwatch logs for the tasks. As they do not exist yet right now it is set as an empty string. Once the tasks have been deployed the parameters will be updated.