### PR TITLE
Remove cloudwatch attributes within task settings

### DIFF
--- a/terraform/staging/task_settings.json
+++ b/terraform/staging/task_settings.json
@@ -104,9 +104,7 @@
         "Id": "FILE_TRANSFER",
         "Severity": "LOGGER_SEVERITY_DEFAULT"
       }
-    ],
-    "CloudWatchLogGroup": "dms-tasks-${dms_replication_instance_name}",
-    "CloudWatchLogStream": "dms-task-${dms_instance_task_resource}"
+    ]
   },
   "ControlTablesSettings": {
     "historyTimeslotInMinutes": 5,


### PR DESCRIPTION
### What
This PR removes the following task settings attributes:

- `CloudWatchLogGroup`
- `CloudWatchLogStream `

### Why
According to AWS this stops the `InvalidParameterValueException: Task Settings CloudWatchLogGroup or CloudWatchLogStream cannot be set on create.` error when trying to deploy a DMS task. (Source: https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Tasks.CustomizingTasks.TaskSettings.Saving.html)