### PR TITLE
Upgrade elastic search for staging

### DIFF
--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -96,10 +96,10 @@ module "elasticsearch_db_staging" {
   project_name     = "addresses-api"
   es_version       = "7.8"
   encrypt_at_rest  = "false"
-  instance_type    = "t2.medium.elasticsearch"
-  instance_count   = "1"
+  instance_type    = "t3.medium.elasticsearch"
+  instance_count   = "3"
   ebs_enabled      = "true"
-  ebs_volume_size  = "20"
+  ebs_volume_size  = "30"
   region           = data.aws_region.current.name
   account_id       = data.aws_caller_identity.current.account_id
   zone_awareness_enabled = false


### PR DESCRIPTION
### What
This PR upgrades the infrastructure for elastic search on staging. It upgrades the instance type to a more optimised version and increases the instance count to 3
### Why
The current elastic search set up on staging is unable to handle the amount of data migrated from the postgres DB and as such needs to be upgraded for it to work.