### PR TITLE
Switch to the Cognito authorizer on `staging` environment.

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -140,7 +140,7 @@ resources:
 custom:
   authorizerArns:
     development: arn:aws:lambda:eu-west-2:859159924354:function:api-auth-verify-token-new-development-apiauthverifytokennew
-    staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-auth-verify-token-new-staging-apiauthverifytokennew
+    staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-gateway-lambda-authorizer
     production:  arn:aws:lambda:eu-west-2:153306643385:function:api-auth-verify-token-new-production-apiauthverifytokennew
   vpc:
     development:


### PR DESCRIPTION
# What:
 - Switch to the Cognito authorizer on `staging` environment.

# Why:
 - Part of the work of rolling out AWS Cognito authentication flow to `staging`.

# Notes:
 - For whatever reason the `development` environment does not exist as far as CCI pipeline's workflows are concerned. As such, I did not update the authorizer for the `development` environment - those deployment jobs are unused. To get that updated, a question should get raised why we don't have that environment and whether we should bring it back up.