### PR TITLE
Switch the `production` lambda authorizer from legacy to cognito supporting one.

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -141,7 +141,7 @@ custom:
   authorizerArns:
     development: arn:aws:lambda:eu-west-2:859159924354:function:api-auth-verify-token-new-development-apiauthverifytokennew
     staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-gateway-lambda-authorizer
-    production:  arn:aws:lambda:eu-west-2:715003523189:function:api-gateway-lambda-authorizer
+    production:  arn:aws:lambda:eu-west-2:153306643385:function:api-gateway-lambda-authorizer
   vpc:
     development:
       subnetIds:

--- a/serverless.yml
+++ b/serverless.yml
@@ -141,7 +141,7 @@ custom:
   authorizerArns:
     development: arn:aws:lambda:eu-west-2:859159924354:function:api-auth-verify-token-new-development-apiauthverifytokennew
     staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-gateway-lambda-authorizer
-    production:  arn:aws:lambda:eu-west-2:153306643385:function:api-auth-verify-token-new-production-apiauthverifytokennew
+    production:  arn:aws:lambda:eu-west-2:715003523189:function:api-gateway-lambda-authorizer
   vpc:
     development:
       subnetIds:


### PR DESCRIPTION
# What:
 - Switch the legacy `production` lambda authorizer for the newer Cognito authentication supporting one.

# Why:
 - Part of the `production` roll-out for the new Cognito authentication.

# Notes:
 - Development is left as is the addresses-api does not appear to have the `development` environment.