### PR TITLE
Resolve `staging` and `production` DMS, ES, and RDS terraform drift.

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -66,10 +66,11 @@ module "postgres_db_production" {
   db_port                  = 5500
   subnet_ids               = data.aws_subnet_ids.production.ids
   db_engine                = "postgres"
-  db_engine_version        = "16.8"
-  db_instance_class        = "db.t3.small"
+  db_engine_version        = "16.13"
+  db_instance_class        = "db.t3.medium"
   db_allocated_storage     = 100
-  db_max_allocated_storage = 250
+  db_max_allocated_storage = 0
+  monitoring_interval      = 0
   maintenance_window       = "sun:10:00-sun:10:30"
   db_username              = data.aws_ssm_parameter.addresses_postgres_username.value
   db_password              = data.aws_ssm_parameter.addresses_postgres_db_password.value

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -210,21 +210,3 @@ module "address-es-dms-local-addresses" {
   target_endpoint_arn = aws_dms_endpoint.address_elasticsearch.endpoint_arn
   task_table_mappings = file("${path.module}/selection_rules_local.json")
 }
-
-# module "address-es-dms-national-addresses" {
-#   source                       = "github.com/LBHackney-IT/aws-dms-terraform.git//dms_replication_task"
-#   environment_name             = "production"
-#   project_name                 = "addresses-api"
-#   migration_type               = "full-load-and-cdc"
-#   replication_instance_arn     = "arn:aws:dms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rep:65CJ5HE2DMCUW5X6EPKTKUDVWA"
-#   replication_task_indentifier = "addresses-api-es-dms-task-national-addresses"
-#   task_settings = templatefile("${path.module}/task_settings.json",
-#     {
-#       dms_replication_instance_name = "production-dms-instance",
-#       dms_instance_task_resource    = "AIB7Y6RGZOCQCUQ7UQHWTW2QNJ5OBWMKDWOBNDA"
-#     }
-#   )
-#   source_endpoint_arn = module.source_db_endpoint.dms_endpoint_arn
-#   target_endpoint_arn = aws_dms_endpoint.address_elasticsearch.endpoint_arn
-#   task_table_mappings = file("${path.module}/selection_rules_national.json")
-# }

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -103,6 +103,8 @@ module "elasticsearch_db_production" {
   ebs_volume_size  = "60"
   region           = data.aws_region.current.name
   account_id       = data.aws_caller_identity.current.account_id
+
+  zone_awareness_enabled = false
 }
 
 data "aws_ssm_parameter" "addresses_elasticsearch_domain" {

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -208,20 +208,20 @@ module "address-es-dms-local-addresses" {
   task_table_mappings = file("${path.module}/selection_rules_local.json")
 }
 
-module "address-es-dms-national-addresses" {
-  source                       = "github.com/LBHackney-IT/aws-dms-terraform.git//dms_replication_task"
-  environment_name             = "production"
-  project_name                 = "addresses-api"
-  migration_type               = "full-load-and-cdc"
-  replication_instance_arn     = "arn:aws:dms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rep:65CJ5HE2DMCUW5X6EPKTKUDVWA"
-  replication_task_indentifier = "addresses-api-es-dms-task-national-addresses"
-  task_settings = templatefile("${path.module}/task_settings.json",
-    {
-      dms_replication_instance_name = "production-dms-instance",
-      dms_instance_task_resource    = "AIB7Y6RGZOCQCUQ7UQHWTW2QNJ5OBWMKDWOBNDA"
-    }
-  )
-  source_endpoint_arn = module.source_db_endpoint.dms_endpoint_arn
-  target_endpoint_arn = aws_dms_endpoint.address_elasticsearch.endpoint_arn
-  task_table_mappings = file("${path.module}/selection_rules_national.json")
-}
+# module "address-es-dms-national-addresses" {
+#   source                       = "github.com/LBHackney-IT/aws-dms-terraform.git//dms_replication_task"
+#   environment_name             = "production"
+#   project_name                 = "addresses-api"
+#   migration_type               = "full-load-and-cdc"
+#   replication_instance_arn     = "arn:aws:dms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rep:65CJ5HE2DMCUW5X6EPKTKUDVWA"
+#   replication_task_indentifier = "addresses-api-es-dms-task-national-addresses"
+#   task_settings = templatefile("${path.module}/task_settings.json",
+#     {
+#       dms_replication_instance_name = "production-dms-instance",
+#       dms_instance_task_resource    = "AIB7Y6RGZOCQCUQ7UQHWTW2QNJ5OBWMKDWOBNDA"
+#     }
+#   )
+#   source_endpoint_arn = module.source_db_endpoint.dms_endpoint_arn
+#   target_endpoint_arn = aws_dms_endpoint.address_elasticsearch.endpoint_arn
+#   task_table_mappings = file("${path.module}/selection_rules_national.json")
+# }

--- a/terraform/production/modules/database/postgres/main.tf
+++ b/terraform/production/modules/database/postgres/main.tf
@@ -32,7 +32,7 @@ resource "aws_db_instance" "lbh-db" {
   vpc_security_group_ids      = [module.db_security_group.db_sg_id]
   db_subnet_group_name        = aws_db_subnet_group.db_subnets.name
   name                        = var.db_name
-  monitoring_interval         = 60 //this is for enhanced Monitoring there will allready be some basic monitering avalable
+  monitoring_interval         = var.monitoring_interval //this is for enhanced Monitoring there will already be some basic monitoring available
   backup_retention_period     = 30
   storage_encrypted           = true
   multi_az                    = var.multi_az

--- a/terraform/production/modules/database/postgres/variables.tf
+++ b/terraform/production/modules/database/postgres/variables.tf
@@ -33,6 +33,10 @@ variable "db_max_allocated_storage" {
   type        = number
   default     = 0
 }
+variable "monitoring_interval" {
+  type    = number
+  default = 0
+}
 variable "maintenance_window" {
   type = string //e.g. "tue:10:00-tue:10:30"
 }

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -226,7 +226,7 @@ module "address-es-dms-local-addresses" {
   task_settings = templatefile("${path.module}/task_settings.json",
     {
       dms_replication_instance_name = "staging-dms-instance",
-      dms_instance_task_resource    = "to-be-updated-local" // Will be updated once the task has been deployed
+      dms_instance_task_resource    = "ZMFZ7R2ZF5BGFNU6T3OTYNWJPE"
     }
   )
   source_endpoint_arn = module.source_db_endpoint.dms_endpoint_arn
@@ -244,7 +244,7 @@ module "address-es-dms-national-addresses" {
   task_settings = templatefile("${path.module}/task_settings.json",
     {
       dms_replication_instance_name = "staging-dms-instance",
-      dms_instance_task_resource    = "to-be-updated-national" // Will be updated once the task has been deployed
+      dms_instance_task_resource    = "ICYNOPE3CNGK7FCOIEUT5XCQ2A"
     }
   )
   source_endpoint_arn = module.source_db_endpoint.dms_endpoint_arn

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -68,7 +68,7 @@ module "postgres_db_staging" {
   db_port               = 5502
   subnet_ids            = data.aws_subnet_ids.staging.ids
   db_engine             = "postgres"
-  db_engine_version     = "16.8"
+  db_engine_version     = "16.13"
   db_instance_class     = "db.t3.micro"
   db_allocated_storage  = 100
   maintenance_window    = "sun:10:00-sun:10:30"

--- a/terraform/staging/modules/dms/main.tf
+++ b/terraform/staging/modules/dms/main.tf
@@ -21,8 +21,8 @@ resource "aws_dms_replication_instance" "address_dms_rep_instance" {
   replication_instance_class  = var.replication_instance_class
   replication_instance_id     = var.replication_instance_identifier
   replication_subnet_group_id = aws_dms_replication_subnet_group.dms_subnet_group.id
-  engine_version              = "3.5.3"
-  auto_minor_version_upgrade  = false
+  engine_version              = "3.5.4"
+  auto_minor_version_upgrade  = true
   publicly_accessible         = false
   allocated_storage           = 20
   availability_zone           = "eu-west-2a"
@@ -36,4 +36,4 @@ resource "aws_dms_replication_instance" "address_dms_rep_instance" {
   }
 
   vpc_security_group_ids = ["sg-0f2b37cc9a9e2cb60"]
-} 
+}

--- a/terraform/staging/task_settings.json
+++ b/terraform/staging/task_settings.json
@@ -27,8 +27,8 @@
     "CommitRate": 10000
   },
   "Logging": {
-    "CloudWatchLogGroup": "dms-tasks-staging-dms-instance",
-    "CloudWatchLogStream": "dms-task-ZMFZ7R2ZF5BGFNU6T3OTYNWJPE",
+    "CloudWatchLogGroup": "dms-tasks-${dms_replication_instance_name}",
+    "CloudWatchLogStream": "dms-task-${dms_instance_task_resource}",
     "EnableLogContext": false,
     "EnableLogging": true,
     "LogComponents": [{

--- a/terraform/staging/task_settings.json
+++ b/terraform/staging/task_settings.json
@@ -171,9 +171,5 @@
   "LoopbackPreventionSettings": null,
   "BeforeImageSettings": null,
   "FailTaskWhenCleanTaskResourceFailed": false,
-  "TTSettings": {
-    "EnableTT": false,
-    "TTRecordSettings": null,
-    "TTS3Settings": null
-  }
+  "TTSettings": null
 }

--- a/terraform/staging/task_settings.json
+++ b/terraform/staging/task_settings.json
@@ -27,6 +27,9 @@
     "CommitRate": 10000
   },
   "Logging": {
+    "CloudWatchLogGroup": "dms-tasks-staging-dms-instance",
+    "CloudWatchLogStream": "dms-task-ZMFZ7R2ZF5BGFNU6T3OTYNWJPE",
+    "EnableLogContext": false,
     "EnableLogging": true,
     "LogComponents": [{
         "Id": "TRANSFORMATION",
@@ -109,6 +112,7 @@
   "ControlTablesSettings": {
     "historyTimeslotInMinutes": 5,
     "ControlSchema": "",
+    "FullLoadExceptionTableEnabled": false,
     "HistoryTimeslotInMinutes": 5,
     "HistoryTableEnabled": false,
     "SuspendedTablesTableEnabled": false,
@@ -126,9 +130,11 @@
   },
   "ErrorBehavior": {
     "DataErrorPolicy": "LOG_ERROR",
+    "DataMaskingErrorPolicy": "STOP_TASK",
     "DataTruncationErrorPolicy": "LOG_ERROR",
     "DataErrorEscalationPolicy": "SUSPEND_TABLE",
     "DataErrorEscalationCount": 0,
+    "EventErrorPolicy": "IGNORE",
     "TableErrorPolicy": "SUSPEND_TABLE",
     "TableErrorEscalationPolicy": "STOP_TASK",
     "TableErrorEscalationCount": 0,
@@ -157,10 +163,13 @@
     "CommitTimeout": 1,
     "MemoryLimitTotal": 1024,
     "MemoryKeepTime": 60,
+    "RecoveryTimeout": -1,
     "StatementCacheSize": 50
   },
   "PostProcessingRules": null,
   "CharacterSetSettings": null,
   "LoopbackPreventionSettings": null,
-  "BeforeImageSettings": null
+  "BeforeImageSettings": null,
+  "FailTaskWhenCleanTaskResourceFailed": false,
+  "TTSettings": null
 }

--- a/terraform/staging/task_settings.json
+++ b/terraform/staging/task_settings.json
@@ -171,5 +171,9 @@
   "LoopbackPreventionSettings": null,
   "BeforeImageSettings": null,
   "FailTaskWhenCleanTaskResourceFailed": false,
-  "TTSettings": null
+  "TTSettings": {
+    "EnableTT": false,
+    "TTRecordSettings": null,
+    "TTS3Settings": null
+  }
 }


### PR DESCRIPTION
# What:
 - Resolve the `production` RDS database `monitoring_interval` drift by updating the local module to take that value as a parameter.
 - Resolve the `production` RDS database `db_max_allocated_storage`, `db_engine_version`, and `db_max_allocated_storage` storage by matching the current values on the cloud.
 - Address the ES database default `availability_zone_count` value being applied by explicitly disabling `zone_awareness_enabled` as it currently is on `production` environment:

```json
{
    ...,
    "ElasticsearchClusterConfig": {
        "InstanceType": "t3.medium.elasticsearch",
        "InstanceCount": 6,
        "DedicatedMasterEnabled": false,
        "ZoneAwarenessEnabled": false,
        "WarmEnabled": false,
        "ColdStorageOptions": {
            "Enabled": false
        }
    },
    ...
}
```
- Remove the `production` `address-es-dms-national-addresses` task as it is not tracked by this Terraform configuration and as such, Terraform tries to create it anew. It hasn't been around for a long time, and if anyone had really missed it, they would have redeployed that by now.
- Resolve the `staging` `aws_dms_replication_instance` engine version drift.
- Resolve the `staging` RDS database `engine_version` drift.
- Resolve the `staging` DMS task settings drift.
- Enable the `production` RDS database deletion protection.

# Why:
 - To unblock the pipeline for upcoming Terraform changes.
 - Enabled deletion protection for extra security - there's no reason that should stay disabled.

# Notes:
 - While the `availability_zone_count` will get added, it won't take effect due to `zone_awareness_enabled` being disabled. It could be prevented from being added, but it's not worth the effort considering it won't have any effect until zone awareness is enabled.
 - The national addresses task that exists and is active is not managed by this Terraform.
 - The `staging` `TTSettings` are explicitly set to `null` to make the AWS use its defaults. It shows keys under this object as being removed, however, in reality they were never set to begin with as when I add them to match the state, the diff states that I'm adding them as if they weren't there before. So clearly this state flicker is caused by AWS implicit defaults.
 ```
  ~ replication_task_settings = jsonencode(
          ~ {
              ~ TTSettings                          = null -> {
                  + EnableTT         = false
                  + TTRecordSettings = null
                  + TTS3Settings     = null
                }
````
- I did not import the ongoing national addresses terraform task from `production` environment onto this TF configuration, as I'm unsure whether the task on the cloud is the same task that is specified here. The addresses sync process is extremely messy and from what I heard is scattered across more than 1 repository. It's possible that the task in question is managed elsewhere by a different team.