### PR TITLE
Prevent `feature` workflow code formatting and tests steps from triggering on `master` branch.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,8 +117,10 @@ jobs:
 workflows:
   feature:
     jobs:
-      - check-code-formatting
-      - build-and-test
+      - check-code-formatting:
+          filters: *ignore_master
+      - build-and-test:
+          filters: *ignore_master
       - assume-role:
           name: assume-role-staging
           context: api-assume-role-staging-context


### PR DESCRIPTION
# What:
 - Prevent the `feature` workflow code formatting and automated tests steps from triggering on `master` branch.

# Why:
 - The necessary code-related checks are already included within the `deploy-api-code-stg-and-prod` workflow.

# Notes:
 - The filters on these `feature` workflow steps were missed among the massive pipeline rework _(see #148 )_ as I've forgot them being parallel (for time-saving reasons) to the Terraform previews.