### PR TITLE
Enable `production` postgres RDS addresses database performance insights.

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -85,6 +85,11 @@ module "postgres_db_production" {
   project_name             = "platform apis"
   deletion_protection      = true
   copy_tags_to_snapshot    = true
+  performance_insights = {
+    enabled           = true
+    retention_period  = 7
+    kms_key_id        = data.aws_kms_key.local_backup_key.arn
+  }
   additional_tags = {
     BackupPolicy = "Prod"
   }

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -57,6 +57,10 @@ data "aws_ssm_parameter" "addresses_postgres_hostname" {
   name = "/addresses-api/production/postgres-hostname"
 }
 
+data "aws_kms_key" "local_backup_key" {
+  key_id = "alias/local-backup-key"
+}
+
 module "postgres_db_production" {
   source                   = "./modules/database/postgres"
   environment_name         = "production"
@@ -75,6 +79,7 @@ module "postgres_db_production" {
   db_username              = data.aws_ssm_parameter.addresses_postgres_username.value
   db_password              = data.aws_ssm_parameter.addresses_postgres_db_password.value
   storage_encrypted        = true
+  kms_key_id               = data.aws_kms_key.local_backup_key.arn
   multi_az                 = true //only true if production deployment
   publicly_accessible      = false
   project_name             = "platform apis"

--- a/terraform/production/modules/database/elasticsearch/main.tf
+++ b/terraform/production/modules/database/elasticsearch/main.tf
@@ -39,8 +39,13 @@ CONFIG
     instance_type          = var.instance_type
     instance_count         = var.instance_count
     zone_awareness_enabled = var.zone_awareness_enabled
-    zone_awareness_config {
-      availability_zone_count = var.availability_zone_count
+
+    dynamic "zone_awareness_config" {
+      for_each = var.zone_awareness_enabled ? [1] : []
+      
+      content {
+        availability_zone_count = var.availability_zone_count
+      }
     }
   }
   ebs_options {

--- a/terraform/production/modules/database/postgres/main.tf
+++ b/terraform/production/modules/database/postgres/main.tf
@@ -35,6 +35,7 @@ resource "aws_db_instance" "lbh-db" {
   monitoring_interval         = var.monitoring_interval //this is for enhanced Monitoring there will already be some basic monitoring available
   backup_retention_period     = 30
   storage_encrypted           = true
+  kms_key_id                  = var.kms_key_id
   multi_az                    = var.multi_az
   auto_minor_version_upgrade  = true
   allow_major_version_upgrade = var.db_allow_major_version_upgrade

--- a/terraform/production/modules/database/postgres/main.tf
+++ b/terraform/production/modules/database/postgres/main.tf
@@ -49,6 +49,11 @@ resource "aws_db_instance" "lbh-db" {
   skip_final_snapshot   = true
   copy_tags_to_snapshot = var.copy_tags_to_snapshot
 
+  # Monitoring
+  performance_insights_enabled          = var.performance_insights.enabled
+  performance_insights_retention_period = var.performance_insights.retention_period
+  performance_insights_kms_key_id       = coalesce(var.performance_insights.kms_key_id, var.kms_key_id)
+
   tags = merge(
     var.additional_tags,
     {

--- a/terraform/production/modules/database/postgres/variables.tf
+++ b/terraform/production/modules/database/postgres/variables.tf
@@ -49,6 +49,11 @@ variable "db_password" {
 variable "storage_encrypted" {
   type = string
 }
+variable "kms_key_id" {
+  description = "The ARN for the KMS encryption key"
+  type        = string
+  default     = null
+}
 variable "multi_az" {
   type = string
 }

--- a/terraform/production/modules/database/postgres/variables.tf
+++ b/terraform/production/modules/database/postgres/variables.tf
@@ -86,3 +86,12 @@ variable "deletion_protection" {
   type        = bool
   default     = false
 }
+variable "performance_insights" {
+  description = "Configuration block for Performance Insights"
+  type = object({
+    enabled          = optional(bool, false)
+    retention_period = optional(number, 7)
+    kms_key_id       = optional(string, null)
+  })
+  default = {}
+}


### PR DESCRIPTION
# What:
- Enable the Performance Insights for the `production` addresses AWS RDS postgres database.
- Specify the missing KMS key in the `production` addresses AWS RDS postgres database.
- Make the `zone_awareness_config` dynamic.

# Why:
 - To get a better understanding of where the slow queries spend most of their time. And what the slow running queries are in general.
 - Added the KMS data block and linked it to the postgres RDS db as I need the key for performance insights, so figured I'd set it on the database for explicitness as well.
 - Despite `zone_awareness_config` taking no effect, I had to make it dynamic to get rid of it from the Terraform previews. I tried applying that zone count attribute addition, but it didn't apply, meaning, it would linger around forever if nothing was done.

# Notes:
- Clearly the database was re-encrypted via the AWS Console, but curiously enough the `terraform plan` did not spot the difference of that the database went from `aws/rds` AWS managed key to `local-backup-key` customer managed key. Might be because the re-encrypted database's import into TF state has overwritten whatever values the TF was aware off from before the encryption.