### PR TITLE
Enable advanced Performance Insights for `production` postgres `addresses` database & Upgrade the AWS provider!

### DIFF
--- a/terraform/production/alarms.tf
+++ b/terraform/production/alarms.tf
@@ -17,7 +17,7 @@ resource "aws_cloudwatch_metric_alarm" "address_api_db_transactions_log_disk_usa
   statistic           = "Average"
 
   dimensions = {
-    DBInstanceIdentifier = "${module.postgres_db_production.instance_id}"
+    DBInstanceIdentifier = "${module.postgres_db_production.instance_identifier}"
   }
 }
 
@@ -34,6 +34,6 @@ resource "aws_cloudwatch_metric_alarm" "address_api_db_free_storage_space" {
   statistic           = "Average"
 
   dimensions = {
-    DBInstanceIdentifier = "${module.postgres_db_production.instance_id}"
+    DBInstanceIdentifier = "${module.postgres_db_production.instance_identifier}"
   }
 }

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -31,7 +31,7 @@ data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
 locals {
-  parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
+  parameter_store = "arn:aws:ssm:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:parameter"
 }
 
 /*    VPC SET UP    */

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -87,8 +87,10 @@ module "postgres_db_production" {
   copy_tags_to_snapshot    = true
   performance_insights = {
     enabled           = true
-    retention_period  = 7
+    # Based on AWS docs: "To turn on Database Insights, the retention period must be at least 465 days."
+    retention_period  = 465
     kms_key_id        = data.aws_kms_key.local_backup_key.arn
+    mode              = "advanced"
   }
   additional_tags = {
     BackupPolicy = "Prod"

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -35,8 +35,12 @@ data "aws_vpc" "production_vpc" {
   }
 }
 
-data "aws_subnet_ids" "production" {
-  vpc_id = data.aws_vpc.production_vpc.id
+data "aws_subnets" "production" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.production_vpc.id]
+  }
+
   filter {
     name   = "tag:Type"
     values = ["private"]
@@ -68,7 +72,7 @@ module "postgres_db_production" {
   db_identifier            = "addresses-api-db-production-emergency-temp"
   db_name                  = "addresses_api"
   db_port                  = 5500
-  subnet_ids               = data.aws_subnet_ids.production.ids
+  subnet_ids               = data.aws_subnets.production.ids
   db_engine                = "postgres"
   db_engine_version        = "16.13"
   db_instance_class        = "db.t3.medium"
@@ -105,7 +109,7 @@ module "elasticsearch_db_production" {
   environment_name = "production"
   port             = 443
   domain_name      = "addresses-api-es"
-  subnet_ids       = [tolist(data.aws_subnet_ids.production.ids)[0]]
+  subnet_ids       = [data.aws_subnets.production.ids[0]]
   project_name     = "addresses-api"
   es_version       = "7.8"
   encrypt_at_rest  = "true"

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.92.0"
+      version = "~> 6.52.0"
     }
   }
 }

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -7,18 +7,6 @@
 # 6) IF ADDITIONAL RESOURCES ARE REQUIRED BY YOUR API, ADD THEM TO THIS FILE
 # 7) ENSURE THIS FILE IS PLACED WITHIN A 'terraform' FOLDER LOCATED AT THE ROOT PROJECT DIRECTORY
 
-provider "aws" {
-  region  = "eu-west-2"
-  version = "~> 5.92.0"
-}
-data "aws_caller_identity" "current" {}
-
-data "aws_region" "current" {}
-
-locals {
-  parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
-}
-
 terraform {
   backend "s3" {
     bucket  = "terraform-state-production-apis"
@@ -26,7 +14,26 @@ terraform {
     region  = "eu-west-2"
     key     = "services/addresses-api/state"
   }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.92.0"
+    }
+  }
 }
+
+provider "aws" {
+  region  = "eu-west-2"
+}
+
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+locals {
+  parameter_store = "arn:aws:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter"
+}
+
 /*    VPC SET UP    */
 
 data "aws_vpc" "production_vpc" {

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -109,13 +109,22 @@ module "postgres_db_production" {
 
 /*    ELASTICSEARCH SETUP    */
 
+# When switching from `aws_subnet_ids` to `aws_subnets` data blocks the order of subnets has changed, 
+# and TF tries to move the ES domain a different subnet. To prevent this, the previously used subnet
+# was filtered by CIDR that is the definition of the subnet id used by this ES domain (see definitions):
+# https://github.com/LBHackney-IT/infrastructure/blob/979206edd3539b11fb17e00c3d97ca849fb713ed/projects/apis-production/config/terraform/prod.tfvars#L3
+data "aws_subnet" "addreses-es-domain" {
+  vpc_id     = data.aws_vpc.production_vpc.id
+  cidr_block = "10.120.8.0/26"
+}
+
 module "elasticsearch_db_production" {
   source           = "./modules/database/elasticsearch"
   vpc_id           = data.aws_vpc.production_vpc.id
   environment_name = "production"
   port             = 443
   domain_name      = "addresses-api-es"
-  subnet_ids       = [data.aws_subnets.production.ids[0]]
+  subnet_ids       = [data.aws_subnet.addreses-es-domain.id]
   project_name     = "addresses-api"
   es_version       = "7.8"
   encrypt_at_rest  = "true"

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -9,7 +9,7 @@
 
 provider "aws" {
   region  = "eu-west-2"
-  version = "~> 2.0"
+  version = "~> 5.92.0"
 }
 data "aws_caller_identity" "current" {}
 

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -41,9 +41,8 @@ data "aws_subnets" "production" {
     values = [data.aws_vpc.production_vpc.id]
   }
 
-  filter {
-    name   = "tag:Type"
-    values = ["private"]
+  tags = {
+    Type = "private"
   }
 }
 

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -31,7 +31,8 @@ data "aws_region" "current" {}
 data "aws_caller_identity" "current" {}
 
 locals {
-  parameter_store = "arn:aws:ssm:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:parameter"
+  current_aws_region = data.aws_region.current.region
+  parameter_store = "arn:aws:ssm:${local.current_aws_region}:${data.aws_caller_identity.current.account_id}:parameter"
 }
 
 /*    VPC SET UP    */
@@ -132,7 +133,7 @@ module "elasticsearch_db_production" {
   instance_count   = "6"
   ebs_enabled      = "true"
   ebs_volume_size  = "60"
-  region           = data.aws_region.current.name
+  region           = local.current_aws_region
   account_id       = data.aws_caller_identity.current.account_id
 
   zone_awareness_enabled = false
@@ -229,7 +230,7 @@ module "address-es-dms-local-addresses" {
   environment_name             = "production"
   project_name                 = "addresses-api"
   migration_type               = "full-load"
-  replication_instance_arn     = "arn:aws:dms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rep:65CJ5HE2DMCUW5X6EPKTKUDVWA"
+  replication_instance_arn     = "arn:aws:dms:${local.current_aws_region}:${data.aws_caller_identity.current.account_id}:rep:65CJ5HE2DMCUW5X6EPKTKUDVWA"
   replication_task_indentifier = "addresses-api-es-dms-task-local-addresses"
   task_settings = templatefile("${path.module}/task_settings.json",
     {

--- a/terraform/production/modules/database/postgres/main.tf
+++ b/terraform/production/modules/database/postgres/main.tf
@@ -53,6 +53,7 @@ resource "aws_db_instance" "lbh-db" {
   performance_insights_enabled          = var.performance_insights.enabled
   performance_insights_retention_period = var.performance_insights.retention_period
   performance_insights_kms_key_id       = coalesce(var.performance_insights.kms_key_id, var.kms_key_id)
+  database_insights_mode                = var.performance_insights.mode
 
   tags = merge(
     var.additional_tags,

--- a/terraform/production/modules/database/postgres/main.tf
+++ b/terraform/production/modules/database/postgres/main.tf
@@ -31,7 +31,7 @@ resource "aws_db_instance" "lbh-db" {
   password                    = var.db_password
   vpc_security_group_ids      = [module.db_security_group.db_sg_id]
   db_subnet_group_name        = aws_db_subnet_group.db_subnets.name
-  name                        = var.db_name
+  db_name                     = var.db_name
   monitoring_interval         = var.monitoring_interval //this is for enhanced Monitoring there will already be some basic monitoring available
   backup_retention_period     = 30
   storage_encrypted           = true

--- a/terraform/production/modules/database/postgres/outputs.tf
+++ b/terraform/production/modules/database/postgres/outputs.tf
@@ -1,3 +1,3 @@
-output "instance_id" {
-  value = aws_db_instance.lbh-db.id
+output "instance_identifier" {
+  value = aws_db_instance.lbh-db.identifier
 }

--- a/terraform/production/modules/database/postgres/variables.tf
+++ b/terraform/production/modules/database/postgres/variables.tf
@@ -92,6 +92,12 @@ variable "performance_insights" {
     enabled          = optional(bool, false)
     retention_period = optional(number, 7)
     kms_key_id       = optional(string, null)
+    mode             = optional(string, "standard")
   })
   default = {}
+
+  validation {
+    condition     = contains(["standard", "advanced"], var.performance_insights.mode)
+    error_message = "performance_insights.mode must be either 'standard' or 'advanced'."
+  }
 }

--- a/terraform/production/task_settings.json
+++ b/terraform/production/task_settings.json
@@ -104,9 +104,7 @@
         "Id": "FILE_TRANSFER",
         "Severity": "LOGGER_SEVERITY_DEFAULT"
       }
-    ],
-    "CloudWatchLogGroup": "dms-tasks-${dms_replication_instance_name}",
-    "CloudWatchLogStream": "dms-task-${dms_instance_task_resource}"
+    ]
   },
   "ControlTablesSettings": {
     "historyTimeslotInMinutes": 5,


### PR DESCRIPTION
# What:
 - Update the `production` postgres module to include `mode` variable for the `performance insights`.
 - Enable `advanced` performance insights against the `production` postgres addresses database.
 - Bump the `production` AWS Terraform provider version from `v2.0` to `v6.52.0` _(latest)_.
 - Replace the `production` `aws_subnet_ids` data block with the `aws_subnets` data source.
 - Replace the `aws_db_instance` `name` attribute with the `db_name`.
 - Move the Terraform `provider`'s deprecated `version` constraint to the `required_providers` block where it now belongs at.
 - Replace the `addresses` ES domain subnet selector from obscure list index to explicit query based on subet's CIDR definition.
 - Remove the `Logging.CloudWatchLogGroup` and the `Logging.CloudWatchLogStream` from the DMS JSON task settings.
 - Update the `production` postgres AWS RDS instance module ouput to return `identifier` attribute instead of the previously used `id`.
 - Replace the `aws_region` `name` attribute with `region`.

# Why:
 - We need the query execution plan analysis to debug the issues with long-running queries, which requires the advanced version of Performance Insights feature.
 - Update the AWS Terraform provider version to make use of the new `database_insights_mode` key after all of its bugs have been fixed _(v6.11.0 - see more in notes)_. However, bumped to `v6.52.0` past what's needed as it's merely minor versions and we may as well reduce the future technical debt now.
 - The `aws_subnet_ids` data block has been deprecated on `v5.0.0` [[tf-docs-v4.67](https://registry.terraform.io/providers/-/aws/4.67.0/docs/data-sources/subnet_ids)], [[tf-docs-v5.0](https://registry.terraform.io/providers/-/aws/5.0.0/docs/data-sources/subnet_ids)]. Last version when it still can be used was `v4.67.0`. Since we're upgrading past this provider version, this long-standing tech debt needs to be fixed.
 - The `aws_db_instance` `name` attribute has been in deprecation for a long time, and was finally completely removed in the `v5.2.0`. Last available AWS Terraform provider version that still allows using the `name` attribute was `v5.1.0` [[docs-deprecated-name](https://registry.terraform.io/providers/hashicorp/aws/5.1.0/docs/resources/db_instance#name-39)].
 - The `version` attribute under the `providers` block has been marked as deprecated [[provider-version-attr-docs](https://developer.hashicorp.com/terraform/language/block/provider#version)]. While it hasn't been removed yet, it will be in the near future. So it's best to do this update now to prevent any future disruptions.
 - After the AWS Terraform provider change, the order in which the `aws_subnets` ids are returned has changed, meaning index 0 no longer points to the same subnet. To resolve this drift, I've tracked down the definition of the previous subnet _(subnet-01d3657f97a243261)_ and found that it's defined by the CIDR _(10.120.8.0/26)_ and is dynamically created from this list [[infrastructure-link](https://github.com/LBHackney-IT/infrastructure/blob/979206edd3539b11fb17e00c3d97ca849fb713ed/projects/apis-production/config/terraform/prod.tfvars#L3)] by a non-Hackney managed TF module. Considering this, the best action is to explicitly grab the subnet id via data block using its CIDR definition. This is because the only incompatibility I foresee with the subnet change at all is that something in the overall organistion's infrastructure related to the address ES may be associated/tied to the IPs the ES domain is expected to be in.
 - The `Logging.CloudWatchLogGroup` and `Logging.CloudWatchLogStream` are now marked as explicitly read-only with strict validation enforcing that. This change was started getting enforced on `v5.46.0` Read more on the issue in [[maintainer-comment](https://github.com/hashicorp/terraform-provider-aws/issues/36997#issuecomment-2101326044)], but from what I understand, this change is primarily driven by the want to reduce needless TF diffs these attributes introduced on every run [[gh-issue](https://github.com/hashicorp/terraform-provider-aws/issues/36598)].
 - The switch from `id` to `identifier` attribute on `aws_db_instance` resource block output had to be done because AWS Terraform provider `v5.0.0` introduced a breaking change that made the `id` attribute point to the database's `resource_id` _(e.g. db-YJFAA8JQD4DCGV4IV4DBMPVVKI)_ instead of database's identifier _(e.g. addresses-api-db-production-emergency-temp)_ like it did before. Read more on [[v5-upgrade-guide](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-5-upgrade#aws_db_instanceid-is-no-longer-the-identifier)].
 - With the release of the AWS Terraform provider `v6.0.0`, the `aws_region` `name` attribute has been marked as deprecated [[v6-aws-region-docs](https://registry.terraform.io/providers/hashicorp/aws/6.0.0/docs/data-sources/region)]. It has been replaced with the `region` attribute within the same block [[v6-migration-guide-region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-6-upgrade#data-source-aws_region)]. This change was forced by the need to bump to v6 to get the minimum require provider version of `v6.11.0`.

# Notes:
 - The performance insights retention period had to be pushed to 15 months (465 days) as based on the feature's requirements at the time of doing this change that's the minimum duration needed to have the advanced insights enabled [[docs-1](https://web.archive.org/web/20260412132230/https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_DatabaseInsights.TurningOnAdvanced.html)] [[docs-2](https://web.archive.org/web/20260629083626/https://aws.amazon.com/blogs/database/deep-dive-into-amazon-aurora-postgresql-lock-analysis-with-cloudwatch-database-insights/)].
 - The AWS Terraform provider version has to be bumped to `v5.92` at a minimum as that's the version where the `database_insights_mode` key under the `aws_db_instance` resource block was first added [[v5.92-docs](https://registry.terraform.io/providers/hashicorp/aws/5.92.0/docs/resources/db_instance#database_insights_mode-5)] (you'll notice this key is not present in [[v5.91-docs](https://registry.terraform.io/providers/hashicorp/aws/5.91.0/docs/resources/db_instance)]).
 - Ehh... :face_exhaling: it seems that the bump to `v5.92` does not suffice because I'm using both the 15 month retention period bump and KMS key for insights against a database that already has `standard` mode of insights enabled. Meaning, this terraform provider version is susceptible to the bugs we're guaranteed to hit during apply:
   1. Performance insights retention not getting passed to AWS when modifying performance insights mode. Fixed in `v6.10` [[issue-42539](https://github.com/hashicorp/terraform-provider-aws/issues/42539)].
   2. Enabling advanced insights mode on an existing database fails appending custom KMS key id when doing an update request. Fixed in `v6.11` for standalone RDS instances [[issue-44046](https://github.com/hashicorp/terraform-provider-aws/issues/44046)].
 - After replacing the deprecated data block of `aws_subnet_ids` with the `aws_subnets`, its exported `ids` data type changes from the `set(string)` to `list(string)` as such any `tolist` conversions can be dropped. Meanwhile, the passing of `data.aws_subnets.production.ids` can be left as is without tweaking any type convertion as based on the documentation it was always supporting a `list(string)` as an input [[db_subnet_group-docs](https://registry.terraform.io/providers/hashicorp/aws/2.70.4/docs/resources/db_subnet_group#subnet_ids-7)]. The reason why it was working with `set(string)` before this `aws_subnets` replacement upgrade is likely the implicit Terraform's type conversion as it's smart enough to figure out the intent.
 - Replaced the generic `filter` syntax for filtering `aws_subnets` based on `tag` filter, with the more concise tags filter syntax [[usage-docs](https://registry.terraform.io/providers/-/aws/6.52.0/docs/data-sources/subnets#example-usage)].
 - The `aws_db_instance` `name` attribute's deprecation and replacement with the `db_name` happened due to apparently common confusion of what it stands for. People commonly believed that the `name` was the RDS instance name as it appears in the AWS console, meanwhile, it was actually the name of the database inside the instance _(sort of like initial catalog)_. As such, it was renamed to reduce confusion.