### PR TITLE
Drop the address usage primary indexes.

### DIFF
--- a/AddressesAPI/Infrastructure/Migrations/20260706142000_RemoveUsagePrimaryIndexes.cs
+++ b/AddressesAPI/Infrastructure/Migrations/20260706142000_RemoveUsagePrimaryIndexes.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace AddressesAPI.Infrastructure.Migrations
+{
+    [Migration("20260706142000_RemoveUsagePrimaryIndexes")]
+    public partial class RemoveUsagePrimaryIndexes : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                "DROP INDEX CONCURRENTLY IF EXISTS dbo.hackney_address_usage_primary_idx;",
+                suppressTransaction: true);
+            migrationBuilder.Sql(
+                "DROP INDEX CONCURRENTLY IF EXISTS dbo.national_address_usage_primary_idx;",
+                suppressTransaction: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                "CREATE INDEX IF NOT EXISTS hackney_address_usage_primary_idx ON dbo.hackney_address USING btree (usage_primary);",
+                suppressTransaction: true);
+            migrationBuilder.Sql(
+                "CREATE INDEX IF NOT EXISTS national_address_usage_primary_idx ON dbo.national_address USING btree (usage_primary);",
+                suppressTransaction: true);
+        }
+    }
+}

--- a/AddressesAPI/Infrastructure/Migrations/AddressesContextModelSnapshot.cs
+++ b/AddressesAPI/Infrastructure/Migrations/AddressesContextModelSnapshot.cs
@@ -15,9 +15,10 @@ namespace AddressesAPI.Infrastructure.Migrations
         {
 #pragma warning disable 612, 618
             modelBuilder
-                .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn)
-                .HasAnnotation("ProductVersion", "3.1.6")
+                .HasAnnotation("ProductVersion", "6.0.36")
                 .HasAnnotation("Relational:MaxIdentifierLength", 63);
+
+            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
             modelBuilder.Entity("AddressesAPI.Infrastructure.CrossReference", b =>
                 {
@@ -51,7 +52,7 @@ namespace AddressesAPI.Infrastructure.Migrations
 
                     b.HasKey("CrossRefKey");
 
-                    b.ToTable("hackney_xref","dbo");
+                    b.ToTable("hackney_xref", "dbo");
                 });
 
             modelBuilder.Entity("AddressesAPI.Infrastructure.HackneyAddress", b =>
@@ -231,7 +232,7 @@ namespace AddressesAPI.Infrastructure.Migrations
 
                     b.HasKey("AddressKey");
 
-                    b.ToTable("hackney_address","dbo");
+                    b.ToTable("hackney_address", "dbo");
                 });
 
             modelBuilder.Entity("AddressesAPI.Infrastructure.NationalAddress", b =>
@@ -411,7 +412,7 @@ namespace AddressesAPI.Infrastructure.Migrations
 
                     b.HasKey("AddressKey");
 
-                    b.ToTable("national_address","dbo");
+                    b.ToTable("national_address", "dbo");
                 });
 #pragma warning restore 612, 618
         }


### PR DESCRIPTION
# What:
 - Add migration to drop the `usage` indexes.
 - Update EF Core model snapshot metadata for v6 compatibility.

# Why:
 - Those indexes were downgrading the database performance due to not being unique enough when considering the amount of rows the tables contain.
 - Added a migration file to ensure the change is tracked via source control as the addition of these same indexes were tracked as well.

# Notes:
 - These index drop changes were already applied manually and yielded up to 10x performance when it comes to average query latency.
 - This PR is merely source control tracker as pipeline migrations have been disabled for the time being.