### PR TITLE
SSI-1182 Add timeout for the api

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -13,6 +13,7 @@ functions:
     name: ${self:service}-${self:provider.stage}
     handler: AddressesAPI::AddressesAPI.LambdaEntryPoint::FunctionHandlerAsync
     role: lambdaExecutionRole
+    timeout: ${self:custom.addressesApiTimeout.${self:provider.stage}}
     package:
       artifact: ./AddressesAPI/bin/release/net8.0/addresses-api.zip
     environment:
@@ -143,6 +144,10 @@ resources:
       Properties:
         QueueName: sqs-addresses-api-reindex-${self:provider.stage}
 custom:
+  addressesApiTimeout:
+    development: 15
+    staging: 15
+    production: 45
   # Nightly reindex cron — off in development (use Lambda console Test instead)
   reindexScheduleEnabled:
     development: false

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -185,10 +185,8 @@ data "aws_subnet" "addreses-es-domain" {
   cidr_block = "10.120.6.0/25"
 }
 
-// robust one-off load/re-load config is 3 instances with t3.medium.elasticsearch
-// this can be scaled back to a minimum (2 instaces/t3.small.elasticsearch) after initial testing 
-//  since we don't have any scheduled tasks on development and the data will be static for the foreseeable future
-// ebs_volume_size has to be at least 50 with production based data
+// robust one-off load/reload config is 3 instances with t3.medium.elasticsearch. This is also a good starting point for day to day development use.
+// ebs_volume_size has to be at least 50 with production based data. That allows re-indexing without pushing too close to the limit
 module "elasticsearch_db_development" {
   source           = "./modules/database/elasticsearch"
   vpc_id           = data.aws_vpc.development_vpc.id


### PR DESCRIPTION
Add configurable timeout for the API lambda. The production value is based on the current setting and the dev and stg have been set to 15s to bump them up from the 6s default one to allow some headroom.

Also updates the ES comment based on what I've seen during the initial setup. Scaling it down would likely cause issues since it's getting pushed pretty hard as is during indexing.